### PR TITLE
Convert generic device/contact artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/btDevices.py
+++ b/scripts/artifacts/btDevices.py
@@ -1,83 +1,80 @@
-import csv
-import os
+__artifacts_v2__ = {
+    "btDevices": {
+        "name": "Bluetooth Devices",
+        "description": "Bluetooth device details from Ford SYNC devlog text logs (BT/devlog_*.txt).",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2021-07-02",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Bluetooth",
+        "notes": "",
+        "paths": ('*/BT/devlog_*.txt',),
+        "output_types": "standard",
+        "artifact_icon": "bluetooth",
+    }
+}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-#Compatability Data
-vehicles = ['Ford Mustang','F-150']
-platforms = ['SYNC3.2V2','SYNCGen3.0_3.0.18093_PRODUC T']
 
-def get_btDevices(files_found, report_folder, seeker, wrap_text):
+@artifact_processor
+def btDevices(context):
     data_list = []
-    for file_found in files_found:
-        with open(file_found, "r") as f:
-            devaddval = manuval = devmodval = supprofval = phonedownval = ''
-            availcodecval = servsupval = subscribenumval = netnameval = ''
-            devsoftval = devfriendval = classdevval = chldval = inbandval = ''
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        devaddval = manuval = devmodval = supprofval = phonedownval = ''
+        availcodecval = servsupval = subscribenumval = netnameval = ''
+        devsoftval = devfriendval = classdevval = chldval = inbandval = brsfval = ''
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
             for line in f:
-                splits = line.split(':',1)
-                totalvalues = len(splits)
-                if totalvalues > 1:
+                splits = line.split(':', 1)
+                if len(splits) > 1:
                     key = splits[0].strip()
                     value = splits[1].strip()
-                    if  key == 'Device Address' :
+                    if key == 'Device Address':
                         devaddval = value
-                    if  key == 'Manufacturer' :
+                    if key == 'Manufacturer':
                         manuval = value.strip('"')
-                    if  key == 'Device Model' :
+                    if key == 'Device Model':
                         devmodval = value
-                    if  key == 'SupportedProfiles' :
+                    if key == 'SupportedProfiles':
                         supprofval = value
-                    if  key == 'Phonebook Download Support' :
-                        phonedownval = value    
-                    if  key == 'Available Codec' :
-                        availcodecval = value    
-                    if  key == 'Service Supported' :
-                        servsupval = value    
-                    if  key == 'subscriberNum' :
-                        subscribenumval = value    
-                    if  key == 'networkName' :
-                        netnameval = value    
-                    if  key == 'deviceSoftwareVersion' :
-                        devsoftval = value    
-                    if  key == 'Device Friendly Name' :
-                        devfriendval = value    
-                    if  key == 'Class Of Device' :
-                        classdevval = value    
-                    if  key == 'CHLD capabilities' :
-                        chldval = value    
+                    if key == 'Phonebook Download Support':
+                        phonedownval = value
+                    if key == 'Available Codec':
+                        availcodecval = value
+                    if key == 'Service Supported':
+                        servsupval = value
+                    if key == 'subscriberNum':
+                        subscribenumval = value
+                    if key == 'networkName':
+                        netnameval = value
+                    if key == 'deviceSoftwareVersion':
+                        devsoftval = value
+                    if key == 'Device Friendly Name':
+                        devfriendval = value
+                    if key == 'Class Of Device':
+                        classdevval = value
+                    if key == 'CHLD capabilities':
+                        chldval = value
                 else:
                     if 'BRSF' in splits[0]:
                         brsfval = splits[0].strip()
                     if 'CHLD' in splits[0]:
-                        eqsplit = splits[0].split('=')
-                        chldval = eqsplit[1].strip()
+                        chldval = splits[0].split('=')[1].strip()
                     if 'In-Band' in splits[0]:
                         inbandval = splits[0].strip()
                     if 'Phonebook' in splits[0]:
                         phonedownval = splits[0].strip()
-        data_list.append((devmodval,manuval,subscribenumval,devfriendval,devaddval,devsoftval,netnameval,supprofval,classdevval,servsupval,availcodecval,phonedownval,chldval,brsfval,inbandval))
-            
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Bluetooth Devices')
-        report.start_artifact_report(report_folder, f'Bluetooth Devices')
-        report.add_script()
-        data_headers = ('Device Model','Manufacturer','Subscriber Number','Device Friendly Name','Device Address','Device Software Version','Network Name','Supported Profiles','Class of Device','Service Supported','Available Codec','Phonebook Download Support','CHLD Capabilities','BRSF','In-Band')
-        file_found = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Bluetooth Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc(f'No Bluetooth Devices available')
+        data_list.append((devmodval, manuval, subscribenumval, devfriendval, devaddval, devsoftval,
+                          netnameval, supprofval, classdevval, servsupval, availcodecval,
+                          phonedownval, chldval, brsfval, inbandval))
 
-
-__artifacts__ = {
-        "Bluetooth": (
-                "Bluetooth",
-                ('*/BT/devlog_*.txt'),
-                get_btDevices)
-}
+    data_headers = ('Device Model', 'Manufacturer', 'Subscriber Number', 'Device Friendly Name',
+                    'Device Address', 'Device Software Version', 'Network Name',
+                    'Supported Profiles', 'Class of Device', 'Service Supported', 'Available Codec',
+                    'Phonebook Download Support', 'CHLD Capabilities', 'BRSF', 'In-Band')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/connDevices.py
+++ b/scripts/artifacts/connDevices.py
@@ -1,68 +1,44 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Chevrolet','Equinox']
-platforms = []
-
-def get_connDevices(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('devices.db'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    datetime(device_master.last_connected_time, 'unixepoch'),
-    device_master.name,
-    device_master.uuid, 
-    device_master.favorite,
-    device_master.visibility
-    
-    
-    FROM device_master
-    
-    order by device_master.last_connected_time ASC
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4]))
-
-        description = 'Connected Devices'
-        report = ArtifactHtmlReport('Connected Devices')
-        report.start_artifact_report(report_folder, 'Connected Devices', description)
-        report.add_script()
-        data_headers = ('Last Connected Time','Device Name', 'UUID', 'Is Favorite?', 'Is Visible?' )
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Connected Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Connected Devices'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-        
-    else:
-        logfunc('No device data available')
-    
-__artifacts__ = {
-        "Connected Devices'": (
-                "Connected Devices'",
-                ('*/devices.db*'),
-                get_connDevices)
+__artifacts_v2__ = {
+    "connDevices": {
+        "name": "Connected Devices",
+        "description": "Connected device history from a vehicle infotainment devices.db.",
+        "author": "gforce4n6",
+        "version": "0.2",
+        "creation_date": "2021-07-20",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Connected Devices",
+        "notes": "",
+        "paths": ('*/devices.db*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    }
 }
 
-        
-        
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, open_sqlite_db_readonly
+
+
+@artifact_processor
+def connDevices(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('devices.db'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT last_connected_time, name, uuid, favorite, visibility
+            FROM device_master
+            ORDER BY last_connected_time ASC
+        ''')
+        for row in cursor.fetchall():
+            timestamp = convert_unix_ts_to_utc(row[0]) if row[0] is not None else ''
+            data_list.append((timestamp, row[1], row[2], row[3], row[4]))
+        db.close()
+
+    data_headers = (('Last Connected Time', 'datetime'), 'Device Name', 'UUID', 'Is Favorite?',
+                    'Is Visible?')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/contactsInfo.py
+++ b/scripts/artifacts/contactsInfo.py
@@ -1,88 +1,58 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Chevrolet','Equinox']
-platforms = []
-
-def get_contactsInfo(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('contact.db'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    SELECT
-    contact_master.first_name,
-    contact_master.middle_name,
-    contact_master.last_name,
-    phone_table.phone_number,
-    contact_master.email_personal,
-    contact_master.email_work,
-    contact_master.email_organization,
-    contact_master.email_other1,
-    contact_master.email_other2,
-    contact_master.org_name,
-    contact_master.position_in_org,
-    contact_master.birth_date,
-    contact_master.note,
-    contact_master.url,
-    contact_master.category,
-    contact_master.fax_number,
-    address_table.addr_street,
-    address_table.addr_city,
-    address_table.addr_state,
-    address_table.addr_zipcode,
-    device_contact.device_id
-    FROM contact_master
-    left JOIN address_table
-    
-    ON address_table.contact_ID = contact_master.contact_ID
-    left join phone_table
-    ON phone_table.contact_ID = contact_master.contact_ID
-    left join device_contact
-    ON device_contact.contact_ID = contact_master.contact_ID
-    ORDER by device_contact.device_id ASC
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11], row[12], row[13], row[14], row[15], row[16], row[17], row[18], row[19], row[20]))
-
-        description = 'Contacts Information'
-        report = ArtifactHtmlReport('Contacts Information')
-        report.start_artifact_report(report_folder, 'Contacts', description)
-        report.add_script()
-        data_headers = ('First Name', 'Middle Name', 'Last Name', 'Phone Number', 'Personal Email', 'Work Email', 'Organization Email', 'Other Email 1', 'Other Email 2', 'Organization', 'Position in Organization', 'Date of Birth', 'Note', 'URL', 'Category', 'Fax', 'Street', 'City', 'State', 'Zip Code', 'Source Phone')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Contacts'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'Contacts'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No contacts data available')
-    
-
-
-__artifacts__ = {
-        "Contacts": (
-                "Contacts",
-                ('*/contact.db*'),
-                get_contactsInfo)
+__artifacts_v2__ = {
+    "contactsInfo": {
+        "name": "Contacts",
+        "description": "Contact records (with phone, email and address) from a vehicle "
+                       "infotainment contact.db.",
+        "author": "gforce4n6",
+        "version": "0.2",
+        "creation_date": "2021-07-19",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Contacts",
+        "notes": "Date of Birth is kept as stored (text); its format varies by head unit.",
+        "paths": ('*/contact.db*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
 }
-        
-        
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def contactsInfo(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('contact.db'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT
+            contact_master.first_name, contact_master.middle_name, contact_master.last_name,
+            phone_table.phone_number, contact_master.email_personal, contact_master.email_work,
+            contact_master.email_organization, contact_master.email_other1,
+            contact_master.email_other2, contact_master.org_name, contact_master.position_in_org,
+            contact_master.birth_date, contact_master.note, contact_master.url,
+            contact_master.category, contact_master.fax_number, address_table.addr_street,
+            address_table.addr_city, address_table.addr_state, address_table.addr_zipcode,
+            device_contact.device_id
+            FROM contact_master
+            LEFT JOIN address_table ON address_table.contact_ID = contact_master.contact_ID
+            LEFT JOIN phone_table ON phone_table.contact_ID = contact_master.contact_ID
+            LEFT JOIN device_contact ON device_contact.contact_ID = contact_master.contact_ID
+            ORDER BY device_contact.device_id ASC
+        ''')
+        for row in cursor.fetchall():
+            data_list.append(tuple(row))
+        db.close()
+
+    data_headers = ('First Name', 'Middle Name', 'Last Name', ('Phone Number', 'phonenumber'),
+                    'Personal Email', 'Work Email', 'Organization Email', 'Other Email 1',
+                    'Other Email 2', 'Organization', 'Position in Organization', 'Date of Birth',
+                    'Note', 'URL', 'Category', ('Fax', 'phonenumber'), 'Street', 'City', 'State',
+                    'Zip Code', 'Source Phone')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
First batch of the **VLEAPP LAVA conversion** — applying the playbook proven on RLEAPP. These are the **first VLEAPP artifacts to actually use `@artifact_processor`** + the context form + LAVA output. (The repo's existing "v2" artifacts only carry a metadata dict over old `ArtifactHtmlReport` bodies, so none produce LAVA data yet.)

## Artifacts
| Module | Name | Source |
|---|---|---|
| `btDevices` | Bluetooth Devices | Ford SYNC `BT/devlog_*.txt` |
| `connDevices` | Connected Devices | infotainment `devices.db` |
| `contactsInfo` | Contacts | infotainment `contact.db` |

## Changes
- `@artifact_processor` + `def fn(context)`; return `(data_headers, data_list, context.get_relative_path(source_path))`.
- **connDevices** — select the raw `last_connected_time` epoch and convert with `convert_unix_ts_to_utc` → aware-UTC datetime, typed `('Col','datetime')` (was a SQLite `datetime(...,'unixepoch')` string). Fixed the key/name typo (`"Connected Devices'"` → `"Connected Devices"`).
- **contactsInfo** — `Phone Number` and `Fax` tagged `('Col','phonenumber')`; Date of Birth kept as text (format varies by head unit).
- **btDevices** — fixed a latent unbound-variable bug (`brsfval` was used but never initialized → `NameError` when a log had no BRSF line).

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit via real `CREATE TABLE` for all three tables: clean.
- Real-sqlite round-trips: connDevices epoch → `2021-08-19 13:16:36 UTC`; contactsInfo 21 columns with phone/fax typed.
- `PluginLoader` loads all three as **`@artifact_processor` v2** artifacts (resolved via `__wrapped__`).

Attribution preserved (btDevices @AlexisBrignoni; connDevices/contactsInfo gforce4n6).

---
This establishes the full-conversion pattern for VLEAPP. Remaining: 24 more v1 artifacts + 12 metadata-only "v2" to upgrade, batched by vehicle/category.