### PR TITLE
Convert Alfa Romeo artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/AlfaRomeo_agenda_BT.py
+++ b/scripts/artifacts/AlfaRomeo_agenda_BT.py
@@ -1,62 +1,60 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Alfa Romeo','Giulia']
-platforms = []
-
-def get_btSyncInfo(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('agenda.sqlite'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    Select
-    BT_DEVICE.LAST_SYNC,
-    BT_DEVICE.BD_ADDRESS
-    From BT_Device
-    order by BT_DEVICE.LAST_SYNC ASC
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1]))
-
-        description = 'Bluetooth Last Sync'
-        report = ArtifactHtmlReport('Bluetooth Last Sync')
-        report.start_artifact_report(report_folder, 'BT Last Sync', description)
-        report.add_script()
-        data_headers = ('Last Sync Date', 'BT Address')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'BT_LastSync'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        tlactivity = 'BT_LastSync'
-        timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No bluetooth sync data available')
-    
-
-
-__artifacts__ = {
-        "Alfa Romeo Bluetooth": (
-                "Alfa Romeo Bluetooth",
-                ('*/agenda.sqlite*'),
-                get_btSyncInfo)
+__artifacts_v2__ = {
+    "alfaRomeoBtSync": {
+        "name": "Alfa Romeo - Bluetooth Last Sync",
+        "description": "Bluetooth device last-sync times from an Alfa Romeo agenda.sqlite.",
+        "author": "gforce4n6",
+        "version": "0.2",
+        "creation_date": "2023-06-16",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Alfa Romeo Vehicles",
+        "notes": "Last Sync Date is interpreted as a Unix epoch (auto-detected seconds/ms) and "
+                 "normalized to UTC; non-numeric values are kept as stored.",
+        "paths": ('*/agenda.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "bluetooth",
+    }
 }
-        
-        
+
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, open_sqlite_db_readonly
+
+
+def _ts(value):
+    if value is None or value == '':
+        return ''
+    if isinstance(value, (int, float)):
+        return convert_unix_ts_to_utc(value)
+    text = str(value).strip()
+    if text.isdigit():
+        return convert_unix_ts_to_utc(int(text))
+    try:
+        dt = datetime.fromisoformat(text.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def alfaRomeoBtSync(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('agenda.sqlite'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT BT_DEVICE.LAST_SYNC, BT_DEVICE.BD_ADDRESS
+            FROM BT_Device
+            ORDER BY BT_DEVICE.LAST_SYNC ASC
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((_ts(row[0]), row[1]))
+        db.close()
+
+    data_headers = (('Last Sync Date', 'datetime'), 'BT Address')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/AlfaRomeo_agenda_contacts.py
+++ b/scripts/artifacts/AlfaRomeo_agenda_contacts.py
@@ -1,70 +1,45 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Alfa Romeo','Giulia']
-platforms = []
-
-#This artifact parses contact information from the
-#The test data we had was limited, so additional information may be added if more test data is gathered.
-
-def get_Contacts(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('agenda.sqlite'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    Select
-    ContactCard.FIRSTNAME,
-    ContactCard.SURNAME,
-    PhoneNumber.NUMBER,
-    BT_Device.BD_ADDRESS
-    from ContactCard
-    left join BT_Device
-    on ContactCard.BT_DEVICE_ID =  BT_Device.ID
-    left join PhoneNumber
-    on ContactCard.ID = PhoneNumber.CONTACT_ID
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2], row[3]))
-
-        description = 'Alfa Romeo Contacts'
-        report = ArtifactHtmlReport('Alfa Romeo Contacts')
-        report.start_artifact_report(report_folder, 'Contacts', description)
-        report.add_script()
-        data_headers = ('First Name', 'Last Name', 'Phone Number', 'BT Address')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'Alfa_Romeo_Contacts'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-        #tlactivity = 'Alfa_Romeo_Contacts'
-        #timeline(report_folder, tlactivity, data_list, data_headers)
-    else:
-        logfunc('No contact data available')
-    
-
-
-__artifacts__ = {
-        "Alfa Romeo Contacts": (
-                "Alfa Romeo Contacts",
-                ('*/agenda.sqlite*'),
-                get_Contacts)
+__artifacts_v2__ = {
+    "alfaRomeoContacts": {
+        "name": "Alfa Romeo - Contacts",
+        "description": "Contacts (with phone numbers and paired BT device) from an Alfa Romeo "
+                       "agenda.sqlite.",
+        "author": "gforce4n6",
+        "version": "0.2",
+        "creation_date": "2023-06-16",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Alfa Romeo Vehicles",
+        "notes": "",
+        "paths": ('*/agenda.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
 }
-        
-        
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def alfaRomeoContacts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('agenda.sqlite'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT ContactCard.FIRSTNAME, ContactCard.SURNAME, PhoneNumber.NUMBER,
+                   BT_Device.BD_ADDRESS
+            FROM ContactCard
+            LEFT JOIN BT_Device ON ContactCard.BT_DEVICE_ID = BT_Device.ID
+            LEFT JOIN PhoneNumber ON ContactCard.ID = PhoneNumber.CONTACT_ID
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((row[0], row[1], row[2], row[3]))
+        db.close()
+
+    data_headers = ('First Name', 'Last Name', ('Phone Number', 'phonenumber'), 'BT Address')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/AlfaRomeo_sdars.py
+++ b/scripts/artifacts/AlfaRomeo_sdars.py
@@ -1,61 +1,41 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, logfunc, tsv, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Alfa Romeo','Giulia']
-platforms = []
-
-def get_sdarsInfo(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('agenda.sqlite'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-    Select
-    siriusdata.value_name,
-    siriusdata.value_description,
-    siriusdata.value_string
-    from siriusdata
-
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    data_list = []  
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list.append((row[0], row[1], row[2]))
-
-        description = 'Sirius Data'
-        report = ArtifactHtmlReport('Alfa Romeo Sirius Settings')
-        report.start_artifact_report(report_folder, 'Sirius Settings', description)
-        report.add_script()
-        data_headers = ('Name', 'Description', 'Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = 'AlfaRomeo_SiriusSettings'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc('No Satellite Digital Audio Radio Service data available')
-    
-
-
-__artifacts__ = {
-        "Alfa Romeo Sirius Data": (
-                "Alfa Romeo Sirius Data",
-                ('*/sdars_db.sqlite*'),
-                get_sdarsInfo)
+__artifacts_v2__ = {
+    "alfaRomeoSirius": {
+        "name": "Alfa Romeo - Sirius Settings",
+        "description": "SiriusXM (SDARS) settings/values from an Alfa Romeo sdars_db.sqlite.",
+        "author": "gforce4n6",
+        "version": "0.2",
+        "creation_date": "2023-06-16",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Alfa Romeo Vehicles",
+        "notes": "",
+        "paths": ('*/sdars_db.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "radio",
+    }
 }
-        
-        
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def alfaRomeoSirius(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('sdars_db.sqlite'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT siriusdata.value_name, siriusdata.value_description, siriusdata.value_string
+            FROM siriusdata
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((row[0], row[1], row[2]))
+        db.close()
+
+    data_headers = ('Name', 'Description', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts the three **Alfa Romeo** (Giulia) artifacts to the full `@artifact_processor` + context-form + LAVA pattern.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `alfaRomeoBtSync` | Alfa Romeo - Bluetooth Last Sync | `agenda.sqlite` → `BT_Device` |
| `alfaRomeoContacts` | Alfa Romeo - Contacts | `agenda.sqlite` → `ContactCard` join |
| `alfaRomeoSirius` | Alfa Romeo - Sirius Settings | `sdars_db.sqlite` → `siriusdata` |

## Changes
- `@artifact_processor` + `def fn(context)`; return `(data_headers, data_list, context.get_relative_path(source_path))`.
- **alfaRomeoBtSync** — `LAST_SYNC` normalized to aware-UTC via `convert_unix_ts_to_utc` (epoch, auto seconds/ms), typed `('Last Sync Date','datetime')`; non-numeric values kept as stored.
- **alfaRomeoContacts** — `Phone Number` tagged `('Phone Number','phonenumber')`.
- Grouped under a single **"Alfa Romeo Vehicles"** category (matching the Ford/Chrysler v2 house style); `paths` normalized to real tuples.
- `creation_date` = original artifact date (2023-06-16); `last_update_date` = conversion date.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit via real `CREATE TABLE` (all 3 tables): clean.
- Real-sqlite round-trips: BT epoch → `2021-08-19 13:16:36 UTC`; contacts phone typed; sirius name/desc/value.
- `PluginLoader` loads all three as `@artifact_processor` v2 artifacts.

Attribution preserved (gforce4n6).