### PR TITLE
Convert Chrysler artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/chrysler_accessories.py
+++ b/scripts/artifacts/chrysler_accessories.py
@@ -1,48 +1,36 @@
-import csv
-import os
-import re
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['FCA','Jeep Cherokee']
-platforms = ['Carplay']
-
-
-
-## Get Accessory data
-def get_accessorydata(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-            with open(file_found, "r") as f:
-                        for line in f:
-                            names = line.split("::")
-                            data_list.append((names[0],names[1]))
-                            #[A-Za-z]+::[A-Za-z]+   -  regex for the accessory_data.txt file
-
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Accessory Data')
-        report.start_artifact_report(report_folder, f'Accessory Data')
-        report.add_script()
-        data_headers = ('Name','Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Accessory Data'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Accessory Data Found')
-
-
-
-        
-
-
-__artifacts__ = {
-       "Accessory Data Chrysler": (
-         "Accessory Data Chrysler",
-         ('*/media/accessory_data.txt'),
-         get_accessorydata)
+__artifacts_v2__ = {
+    "chryslerAccessories": {
+        "name": "Chrysler - Accessory Data",
+        "description": "Accessory data (name::value pairs) from a Chrysler media/accessory_data.txt.",
+        "author": "Joe Dinsmoor",
+        "version": "0.2",
+        "creation_date": "2023-06-08",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Chrysler Vehicles",
+        "notes": "",
+        "paths": ('*/media/accessory_data.txt',),
+        "output_types": "standard",
+        "artifact_icon": "sliders",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def chryslerAccessories(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for line in f:
+                names = line.split("::")
+                if len(names) < 2:
+                    continue
+                data_list.append((names[0].strip(), names[1].strip()))
+
+    data_headers = ('Name', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_bt.py
+++ b/scripts/artifacts/chrysler_bt.py
@@ -1,54 +1,41 @@
-import csv
-import os
-import re
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['FCA','Jeep Cherokee']
-platforms = ['Carplay']
-
-## Get connected Bluetooth Devices
-def get_btDevices(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        with open(file_found, "r") as f:
-            devAddr = devFriendlyName = '' # Look for device addresses (hex) & friendly names
-            for line in f:  # Search line for certain keywords
-                splits1 = ''
-                splits2 = ''
-                if 'bdAddr: ' in line:
-                    splits1 = line.split('bdAddr: ')
-                    line = next(f)
-                    line = next(f)
-                    if 'name: ' in line:
-                        splits2 = line.split('name: ')
-                        devAddr = splits1[1]
-                        devFriendlyName = splits2[1]
-                    else: 
-                        devAddr = devFriendlyName = ''
-                # Add found item pair to data list                
-                if (devAddr, devFriendlyName) not in data_list and devAddr != '':
-                    data_list.append((devAddr, devFriendlyName)) # Add new found data to datalist
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Bluetooth Devices')
-        report.start_artifact_report(report_folder, f'Bluetooth Devices')
-        report.add_script()
-        data_headers = ('Device Address','Device Friendly Name')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Bluetooth Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Bluetooth Devices found')
-
-
-
-__artifacts__ = {
-    "bluetooth_devices": (
-        "bluetooth devices",
-        ('*/betula/bt_log.txt'),
-        get_btDevices),
+__artifacts_v2__ = {
+    "chryslerBtDevices": {
+        "name": "Chrysler - Bluetooth Devices",
+        "description": "Paired Bluetooth devices (address + friendly name) from a Chrysler "
+                       "betula/bt_log.txt.",
+        "author": "Joe Dinsmoor",
+        "version": "0.2",
+        "creation_date": "2023-06-02",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Chrysler Vehicles",
+        "notes": "",
+        "paths": ('*/betula/bt_log.txt',),
+        "output_types": "standard",
+        "artifact_icon": "bluetooth",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def chryslerBtDevices(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for line in f:
+                if 'bdAddr: ' not in line:
+                    continue
+                dev_addr = line.split('bdAddr: ')[1].strip()
+                next(f, '')
+                name_line = next(f, '')
+                dev_name = name_line.split('name: ')[1].strip() if 'name: ' in name_line else ''
+                if dev_addr and (dev_addr, dev_name) not in data_list:
+                    data_list.append((dev_addr, dev_name))
+
+    data_headers = ('Device Address', 'Device Friendly Name')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_contacts.py
+++ b/scripts/artifacts/chrysler_contacts.py
@@ -1,55 +1,38 @@
-import csv
-import os
-import re
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['FCA','Jeep Cherokee']
-platforms = ['Carplay']
-
-
-
-## Get known contacts
-def get_contacts(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        with open(file_found, "r") as f:
-            name = ''
-            information = ''
-            count = 0
-            for line in f:
-                line_str = str(line)
-                line_str_decoded = bytes(line_str, "utf-8").decode("unicode_escape", errors="replace")
-                line_decoded = re.sub('r\\\\x[0-9a-fA-F]{2}', "", line_str_decoded)
-                line_wanted = line_decoded.encode('ascii', 'ignore').decode('ascii', errors="replace")
-                splits = ''
-                if count%2==0:
-                    name = line
-                else:
-                    information = line
-                    if (name not in data_list):
-                        data_list.append((name, information))  
-                count += 1   
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Contacts List')
-        report.start_artifact_report(report_folder, f'Contacts List')
-        report.add_script()
-        data_headers = ('Name','Information')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-    
-        tsvname = f'Contacts List'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Contacts')
-
-
-__artifacts__ = {
-       "contactList": (
-        "contactsList",
-        ('*/voice/asr/context/phonebook/*.txt'),
-        get_contacts)
+__artifacts_v2__ = {
+    "chryslerContacts": {
+        "name": "Chrysler - Contacts List",
+        "description": "Voice-recognition phonebook contacts (name/information pairs) from a "
+                       "Chrysler voice/asr phonebook export.",
+        "author": "Joe Dinsmoor",
+        "version": "0.2",
+        "creation_date": "2023-06-05",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Chrysler Vehicles",
+        "notes": "Lines are read as alternating name / information pairs, as in the original.",
+        "paths": ('*/voice/asr/context/phonebook/*.txt',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def chryslerContacts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            name = ''
+            for count, line in enumerate(f):
+                if count % 2 == 0:
+                    name = line.strip()
+                else:
+                    data_list.append((name, line.strip()))
+
+    data_headers = ('Name', 'Information')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_devices.py
+++ b/scripts/artifacts/chrysler_devices.py
@@ -1,62 +1,43 @@
 __artifacts_v2__ = {
     "Device_Manager_Devices": {
         "name": "Device Manager Devices",
-        "description": "Scrapes the device history from Chrysler Vehicles",
-        "author": "@JaysonU25",  # Replace with the actual author's username or name
-        "version": "0.1",  # Version number
-        "date": "2024-10-09",  # Date of the latest version
+        "description": "Device manager history from Chrysler vehicles (DeviceManagerDeviceList "
+                       "bz2-compressed sqlite).",
+        "author": "@JaysonU25",
+        "version": "0.2",
+        "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29",
         "requirements": "none",
         "category": "Chrysler Vehicles",
         "notes": "",
-        "paths": ('*/*DeviceManagerDeviceList.bz*'),
-        "function": "get_devices"
+        "paths": ('*/*DeviceManagerDeviceList.bz*',),
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+        "function": "get_devices",
     }
 }
-import csv
-import os
-import re
+
 import bz2
 import sqlite3
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor
 
-#Compatability Data
-vehicles = ['FCA','Grand Cherokee']
-platforms = ['']
 
-def get_devices(files_found, report_folder, seeker, wrap_text):
+@artifact_processor
+def get_devices(context):
     data_list = []
-    for file_found in files_found:
-        devAddr = []
-        devFriendlyName = []
-        with bz2.BZ2File(file_found) as f:   
-            db = sqlite3.Connection(":memory:")
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with bz2.BZ2File(file_found) as f:
+            db = sqlite3.connect(':memory:')
             db.deserialize(f.read())
             cursor = db.cursor()
-            cursor.execute('''
-            Select
-            name, address
-            From DeviceListTable
-            ''')
-            all_rows = cursor.fetchall()
-            
-            usageentries = len(all_rows)
-            data_list = []  
-            
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0], row[1]))
- 
+            cursor.execute('SELECT name, address FROM DeviceListTable')
+            for row in cursor.fetchall():
+                data_list.append((row[0], row[1]))
+            db.close()
 
-    if len(data_list) > 0: # Check to see if Data found
-        report = ArtifactHtmlReport('Device Manager Devices')
-        report.start_artifact_report(report_folder, f'Device Manager Devices')
-        report.add_script()
-        data_headers = ("Device Name", "Address")
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Device Manager Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Devices found')
+    data_headers = ('Device Name', 'Address')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_diag.py
+++ b/scripts/artifacts/chrysler_diag.py
@@ -1,50 +1,37 @@
-import csv
-import os
-import re
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['FCA','Jeep Cherokee']
-platforms = ['Carplay']
-
-def get_diagnosticdata(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        with open(file_found, "r") as f:
-            id = ''
-            val = ''
-            count = 0
-            for line in f:
-                splits = ''
-                #Search for key values in the diagnostic logs
-                if count%2==0:
-                    id = line
-                else:
-                    val = line
-                    if (id not in data_list):
-                        data_list.append((id, val))  
-                count += 1           
-    if len(data_list) > 0:
-        #Send new data to report generator
-        report = ArtifactHtmlReport('Diagnostic Data')
-        report.start_artifact_report(report_folder, f'Diagnostic Data')
-        report.add_script()
-        data_headers = ('Key','Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-    
-        tsvname = f'Vehicle Info'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Diagnostic Data')
-
-
-__artifacts__ = {
-        "diagnostic_data": (
-        "diagnostic_data",
-        ('*/persistence/nonvol_*.ps'),
-        get_diagnosticdata)
+__artifacts_v2__ = {
+    "chryslerDiagnostics": {
+        "name": "Chrysler - Diagnostic Data",
+        "description": "Diagnostic key/value data from a Chrysler persistence/nonvol_*.ps log.",
+        "author": "Joe Dinsmoor",
+        "version": "0.2",
+        "creation_date": "2023-06-02",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Chrysler Vehicles",
+        "notes": "Lines are read as alternating key / value pairs, as in the original.",
+        "paths": ('*/persistence/nonvol_*.ps',),
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def chryslerDiagnostics(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            key = ''
+            for count, line in enumerate(f):
+                if count % 2 == 0:
+                    key = line.strip()
+                else:
+                    data_list.append((key, line.strip()))
+
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_gps.py
+++ b/scripts/artifacts/chrysler_gps.py
@@ -1,65 +1,66 @@
-import csv
-import os
-import re
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['FCA','Jeep Cherokee']
-platforms = ['Carplay']
-
-
-
-## Get GPS data
-def get_gpsdata(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        try:
-            with open(file_found, "r", encoding = "ISO-8859-1") as f:
-                for line in f:
-                    long = []
-                    lat = []
-                    try:
-                        line_str = str(line)
-                        line_str_decoded = bytes(line_str, "utf-8").decode("unicode_escape", errors="replace")
-                        line_decoded = re.sub('r\\\\x[0-9a-fA-F]{2}', "", line_str_decoded)
-                        line_wanted = line_decoded.encode('ascii', 'ignore').decode('ascii', errors="replace") 
-                        if "Latitude" in line_wanted:
-                            for i in re.findall(r"Latitude\sread\sfrom\sPS:\s([+-]?(?=\.\d|\d)(?:\d+)?(?:\.?\d*))(?:[Ee]([+-]?\d+))?", line_wanted):
-                                lat.append(i)
-                        if "Longitude" in line_wanted:
-                            for i in re.findall(r"Longitude\sread\sfrom\sPS:\s([+-]?(?=\.\d|\d)(?:\d+)?(?:\.?\d*))(?:[Ee]([+-]?\d+))?", line_wanted):
-                                long.append(i)
-                        if len(long) > 0 or len(lat) > 0:
-                            if ((lat[0], long[0])) not in data_list: 
-                                data_list.append((lat[0], long[0]))
-                    except UnicodeDecodeError:
-                        pass
-        except PermissionError:
-            print("directory is not writable")
-
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('GPS Info')
-        report.start_artifact_report(report_folder, f'GPS Info')
-        report.add_script()
-        data_headers = ('Latitude','Longitude')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'GPS Info'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No GPS Info Found')
-
-
-        
-
-
-__artifacts__ = {
-       "gps_data": (
-         "gps_data",
-         ('*/log/slogs*'),
-         get_gpsdata)
+__artifacts_v2__ = {
+    "chryslerGps": {
+        "name": "Chrysler - GPS",
+        "description": "GPS latitude/longitude fixes scraped from Chrysler slog files.",
+        "author": "Joe Dinsmoor",
+        "version": "0.2",
+        "creation_date": "2023-06-05",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are exposed for the KML map. Each longitude is paired with "
+                 "the most recently seen latitude, so fixes split across consecutive log lines are "
+                 "captured (the original required both on one line and could raise on a "
+                 "latitude-only line).",
+        "paths": ('*/log/slogs*',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    }
 }
+
+import re
+
+from scripts.ilapfuncs import artifact_processor
+
+_LAT_RE = re.compile(r"Latitude\sread\sfrom\sPS:\s([+-]?(?=\.\d|\d)(?:\d+)?(?:\.?\d*))"
+                     r"(?:[Ee]([+-]?\d+))?")
+_LON_RE = re.compile(r"Longitude\sread\sfrom\sPS:\s([+-]?(?=\.\d|\d)(?:\d+)?(?:\.?\d*))"
+                     r"(?:[Ee]([+-]?\d+))?")
+
+
+def _num(match):
+    # re.findall returns (value, exponent) tuples; rebuild the numeric string.
+    value, exp = match
+    return value + ('e' + exp if exp else '')
+
+
+@artifact_processor
+def chryslerGps(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        last_lat = None
+        try:
+            with open(file_found, 'r', encoding='ISO-8859-1') as f:
+                for line in f:
+                    line_clean = (bytes(str(line), 'utf-8')
+                                  .decode('unicode_escape', errors='replace')
+                                  .encode('ascii', 'ignore').decode('ascii', errors='replace'))
+                    if 'Latitude' in line_clean:
+                        lats = [_num(m) for m in _LAT_RE.findall(line_clean)]
+                        if lats:
+                            last_lat = lats[0]
+                    if 'Longitude' in line_clean:
+                        lons = [_num(m) for m in _LON_RE.findall(line_clean)]
+                        if lons and last_lat is not None:
+                            pair = (last_lat, lons[0])
+                            if pair not in data_list:
+                                data_list.append(pair)
+                            last_lat = None
+        except (PermissionError, UnicodeDecodeError):
+            continue
+
+    data_headers = ('Latitude', 'Longitude')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_logs.py
+++ b/scripts/artifacts/chrysler_logs.py
@@ -1,69 +1,55 @@
 __artifacts_v2__ = {
     "Location_logs": {
         "name": "Location Logs",
-        "description": "Scrapes the log data from Chrysler Vehicles",
-        "author": "@JaysonU25",  # Replace with the actual author's username or name
-        "version": "0.1",  # Version number
-        "date": "2024-10-07",  # Date of the latest version
+        "description": "GPS location fixes (with accuracy, speed, course) parsed from Chrysler "
+                       "JSR179 persistent logs.",
+        "author": "@JaysonU25",
+        "version": "0.2",
+        "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29",
         "requirements": "none",
         "category": "Chrysler Vehicles",
-        "notes": "",
-        "paths": ('*/persistentLogs/*/Log*'),
-        "function": "get_location_logs"
+        "notes": "Latitude/Longitude are exposed for the KML map.",
+        "paths": ('*/persistentLogs/*/Log*',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+        "function": "get_location_logs",
     }
 }
 
-import csv
-import os
-import re
-import datetime
+from scripts.ilapfuncs import artifact_processor
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
 
-#Compatability Data
-vehicles = ['FCA','Grand Cherokee']
-platforms = ['']
-
-def get_location_logs(files_found, report_folder, seeker, wrap_text):
+@artifact_processor
+def get_location_logs(context):
     data_list = []
-    for file_found in files_found:
-        with open(file_found, "r", encoding='cp437') as f:
-            date = time = latitude = longitude = zip_code = speed = altitude = course = h_acc = v_acc = azimuth = method = '' # Initialize Variables
-            for line in f:  # Search line for certain keywords
-                if line == "":
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, 'r', encoding='cp437') as f:
+            for line in f:
+                if "JSR179InterfaceImpl [INFO] " not in line:
                     continue
-                splits1 = ''
-                splits2 = ''
-                if "JSR179InterfaceImpl [INFO] " in line:
-                    splits1 = line.split(" ")
-                    date = splits1[0].strip()
-                    time = splits1[1].strip()[0:-4]
-                    splits2 = line.split(" ")
-                    method = "N/A" if splits2[-2] == ";" else splits2[-2][0:-1]  # Grab index we need but also remove trailing semicolon
-                    azimuth = splits2[-5][0:-1]
-                    speed = splits2[-7][0:-1]
-                    course = splits2[-9][0:-1]
-                    v_acc = splits2[-14][0:-1]
-                    h_acc = splits2[-17][0:-1]
-                    altitude = splits2[-20][0:-1]
-                    zip_code = "Not found" if splits2[-22] == ";" else splits2[-22][0:-1] 
-                    longitude = splits2[-25][0:-1]
-                    latitude = splits2[-27][0:-1]
-                    
-                # Add found item to data list                
-                if (date, time, latitude, longitude, zip_code, altitude, h_acc, v_acc, course, speed, azimuth, method) not in data_list and date != '' and time != "" and latitude != "" and longitude != "":
-                    data_list.append((date, time, latitude, longitude, zip_code, altitude, h_acc, v_acc, course, speed, azimuth, method)) # Add new found data to datalist
-    
-    if len(data_list) > 0: # Check to see if Data found
-        report = ArtifactHtmlReport('Location Logs')
-        report.start_artifact_report(report_folder, f'Location Logs')
-        report.add_script()
-        data_headers = ('Date', 'Time', "Latitude", "Longitude", "Zip Code", "Altitude", "Horizontal Accuracy", "Vertical Accuracy", "Course", "Speed", "Azimuth", "Location Method")
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Location Logs'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Location Logs found')
+                splits = line.split(" ")
+                date = splits[0].strip()
+                time = splits[1].strip()[0:-4]
+                method = "N/A" if splits[-2] == ";" else splits[-2][0:-1]
+                azimuth = splits[-5][0:-1]
+                speed = splits[-7][0:-1]
+                course = splits[-9][0:-1]
+                v_acc = splits[-14][0:-1]
+                h_acc = splits[-17][0:-1]
+                altitude = splits[-20][0:-1]
+                zip_code = "Not found" if splits[-22] == ";" else splits[-22][0:-1]
+                longitude = splits[-25][0:-1]
+                latitude = splits[-27][0:-1]
+                row = (date, time, latitude, longitude, zip_code, altitude, h_acc, v_acc, course,
+                       speed, azimuth, method)
+                if date and time and latitude and longitude and row not in data_list:
+                    data_list.append(row)
 
+    data_headers = ('Date', 'Time', 'Latitude', 'Longitude', 'Zip Code', 'Altitude',
+                    'Horizontal Accuracy', 'Vertical Accuracy', 'Course', 'Speed', 'Azimuth',
+                    'Location Method')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/chrysler_phonebook.py
+++ b/scripts/artifacts/chrysler_phonebook.py
@@ -1,64 +1,61 @@
 __artifacts_v2__ = {
     "PhoneBook_Devices": {
         "name": "PhoneBook Devices",
-        "description": "Scrapes the Phonebook data from Chrysler Vehicles",
-        "author": "@JaysonU25",  # Replace with the actual author's username or name
-        "version": "0.1",  # Version number
-        "date": "2024-10-09",  # Date of the latest version
+        "description": "Phonebook BT device list with connect/disconnect times from Chrysler "
+                       "vehicles (PhoneBookDeviceList bz2-compressed sqlite).",
+        "author": "@JaysonU25",
+        "version": "0.2",
+        "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29",
         "requirements": "none",
         "category": "Chrysler Vehicles",
-        "notes": "",
-        "paths": ('*/*PhoneBookDeviceList.bz*'),
-        "function": "get_phone_book_devices"
+        "notes": "Last Connected / Last Disconnected interpreted as Unix epochs and normalized to "
+                 "UTC; non-numeric values kept as stored.",
+        "paths": ('*/*PhoneBookDeviceList.bz*',),
+        "output_types": "standard",
+        "artifact_icon": "phone",
+        "function": "get_phone_book_devices",
     }
 }
 
-import csv
-import os
-import re
 import bz2
 import sqlite3
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-#Compatability Data
-vehicles = ['FCA','Grand Cherokee']
-platforms = ['']
 
-def get_phone_book_devices(files_found, report_folder, seeker, wrap_text):
+def _ts(value):
+    if value is None or value == '':
+        return ''
+    if isinstance(value, (int, float)):
+        return convert_unix_ts_to_utc(value)
+    text = str(value).strip()
+    if text.isdigit():
+        return convert_unix_ts_to_utc(int(text))
+    try:
+        dt = datetime.fromisoformat(text.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def get_phone_book_devices(context):
     data_list = []
-    for file_found in files_found:
-        devAddr = []
-        devFriendlyName = []
-        with bz2.BZ2File(file_found) as f:   
-            db = sqlite3.Connection(":memory:")
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with bz2.BZ2File(file_found) as f:
+            db = sqlite3.connect(':memory:')
             db.deserialize(f.read())
             cursor = db.cursor()
-            cursor.execute('''
-            Select
-            DeviceAddress, LastConnected, LastDisconnected
-            From T_BTDevice
-            ''')
-            all_rows = cursor.fetchall()
-            
-            usageentries = len(all_rows)
-            data_list = []  
-            
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2]))
- 
+            cursor.execute('SELECT DeviceAddress, LastConnected, LastDisconnected FROM T_BTDevice')
+            for row in cursor.fetchall():
+                data_list.append((row[0], _ts(row[1]), _ts(row[2])))
+            db.close()
 
-    if len(data_list) > 0: # Check to see if Data Found
-        report = ArtifactHtmlReport('PhoneBook Devices')
-        report.start_artifact_report(report_folder, f'PhoneBook Devices')
-        report.add_script()
-        data_headers = ("Device Mac Address", "Last Connected", "Last Disconnected")
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'PhoneBook Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No PhoneBook Devices found')
-
+    data_headers = ('Device Mac Address', ('Last Connected', 'datetime'),
+                    ('Last Disconnected', 'datetime'))
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts all **eight Chrysler (FCA)** artifacts to the full `@artifact_processor` + context-form + LAVA pattern. Five were v1 `__artifacts__`; three were "v2" in name only (metadata dict over an old `ArtifactHtmlReport` body) and now actually produce LAVA output.

## Artifacts
| Module | Name | Source | Notes |
|---|---|---|---|
| `chryslerAccessories` | Chrysler - Accessory Data | `media/accessory_data.txt` | guards lines without `::` |
| `chryslerBtDevices` | Chrysler - Bluetooth Devices | `betula/bt_log.txt` | name avoids clash with Ford "Bluetooth Devices" |
| `chryslerContacts` | Chrysler - Contacts List | voice/asr phonebook | |
| `chryslerDiagnostics` | Chrysler - Diagnostic Data | `persistence/nonvol_*.ps` | |
| `chryslerGps` | Chrysler - GPS | `log/slogs*` | **KML** + bug fixes |
| `Device_Manager_Devices` | Device Manager Devices | bz2 sqlite | metadata-only → real body |
| `PhoneBook_Devices` | PhoneBook Devices | bz2 sqlite | metadata-only → real body; times → UTC |
| `Location_logs` | Location Logs | JSR179 logs | metadata-only → real body; **KML** |

## 🐞 chryslerGps fixes
- The original stored the regex **`(value, exponent)` tuples** in the Latitude/Longitude cells (e.g. `('40.7128', '')`); now emits the clean numeric string.
- It required lat+lon on **one line** and could `IndexError` on a latitude-only line. Now each longitude is paired with the **most recent latitude**, so fixes split across consecutive log lines are captured (verified on both same-line and separate-line formats).

## LAVA specifics
- `chryslerGps` + `Location_logs`: `output_types` includes `'kml'` with exact `Latitude`/`Longitude` columns for the map.
- `PhoneBook_Devices`: `Last Connected`/`Last Disconnected` normalized to aware-UTC.
- The 3 metadata-only artifacts keep their existing keys + `"function"` key; the loader resolves them with `@artifact_processor` (verified).

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit (all 8 tables): clean.
- Functional tests: accessories `::` parse + bad-line skip; GPS both line formats; Location Logs negative-index parse; bz2-sqlite bodies.
- `PluginLoader` loads all eight (incl. the 3 `"function"`-key + `@artifact_processor`).

`creation_date` = each original's date; `last_update_date` = conversion. Attribution preserved (Joe Dinsmoor; @JaysonU25).