### PR TITLE
Convert core Hyundai artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/hyundai_callHistory.py
+++ b/scripts/artifacts/hyundai_callHistory.py
@@ -1,122 +1,63 @@
-import csv
-import os
-import sqlite3
-import re
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Hyundai Sonata']
-platforms = ['Carplay']
-
-def get_callHistory(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        db = open_sqlite_db_readonly(file_found)
-        db_name = os.path.splittext(file_found)
-        cursor = db.cursor()
-        
-
-        cursor.execute("SELECT _id from bluetooth_callhistory")
-        ids = cursor.fetchall()
-
-        cursor.execute("SELECT given_name from bluetooth_callhistory")
-        givens = cursor.fetchall()
-
-        cursor.execute("SELECT family_name from bluetooth_callhistory")
-        familys = cursor.fetchall()
-
-        cursor.execute("SELECT phone_number from bluetooth_callhistory")
-        phone_numbers = cursor.fetchall()
-
-        cursor.execute("SELECT calltype from bluetooth_callhistory")
-        callTypes = cursor.fetchall()
-
-
-        cursor.execute("SELECT date from bluetooth_callhistory")
-        dates = cursor.fetchall()
-
-        cursor.execute("SELECT date_sort from bluetooth_callhistory")
-        date_sorts = cursor.fetchall()
-
-        cursor.execute("SELECT duration from bluetooth_callhistory")
-        durations = cursor.fetchall()
-
-        cursor.execute("SELECT numberType from bluetooth_callhistory")
-        numberTypes = cursor.fetchall()
-        i = 0
-
-        ti = []
-        tg = []
-        tf = []
-        tn = []
-        tc = []
-        td = []
-        tds = []
-        tdu = []
-        tnt = []
-        
-        for id in ids:
-            id = str(id)
-            id = re.sub(r'\W+', '', id)
-            ti.append(id)
-        for given in givens:
-            given = str(given)
-            given = re.sub(r'\W+', '', given)
-            tg.append(given)
-        for family in familys:
-            family = str(family)
-            family = re.sub(r'\W+', '', family)
-            tf.append(family)
-        for number in phone_numbers:
-            number = str(number)
-            number = re.sub(r'\W+', '', number)
-            tn.append(number)
-        for ct in callTypes:
-            ct = str(ct)
-            ct = re.sub(r'\W+', '', ct)
-            tc.append(ct)
-        for date in dates:
-            date = str(date)
-            date = re.sub(r'\W+', '', date)
-            td.append(date)
-        for ds in date_sorts:
-            ds = str(ds)
-            ds = re.sub(r'\W+', '', ds)
-            tds.append(ds)
-        for duration in durations:
-            duration = str(duration)
-            duration = re.sub(r'\W', '', duration)
-            tdu.append(duration)
-        for nt in numberTypes:
-            nt = str(nt)
-            nt = re.sub(r'\W', '', nt)
-            tnt.append(nt)
-        if db_name[1] == 'db':
-            break
-
-
-    #append array for each column to data_list, push data_list to report
-        for id in ids:
-            data_list.append((ti[i], tg[i], tf[i], tn[i], tc[i], td[i], tds[i], tdu[i], tnt[i]))
-            i += 1
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Call History')
-        report.start_artifact_report(report_folder, f'Call History')
-        report.add_script()
-        data_headers = ('id','given_name', 'family_name', 'phone_number', 'calltype', 'date', 'date_sort', 'duration', 'numberType')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Call History'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Call History found')
-
-
-__artifacts__ = {
-    "call history": (
-        "call history",
-        ('*/bluetooth/DB_BMS/CH_*.db*'),
-        get_callHistory),
+__artifacts_v2__ = {
+    "hyundaiCallHistory": {
+        "name": "Hyundai - Call History",
+        "description": "Bluetooth call history from a Hyundai infotainment CH_*.db.",
+        "author": "Nixy Camacho",
+        "version": "0.2",
+        "creation_date": "2023-06-09",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Hyundai Vehicles",
+        "notes": "Rewritten as a single query (the original ran nine separate SELECTs and crashed on "
+                 "os.path.splittext). date / date_sort are interpreted as Unix epochs and "
+                 "normalized to UTC.",
+        "paths": ('*/bluetooth/DB_BMS/CH_*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    }
 }
+
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc, open_sqlite_db_readonly
+
+
+def _ts(value):
+    if value is None or value == '':
+        return ''
+    if isinstance(value, (int, float)):
+        return convert_unix_ts_to_utc(value)
+    text = str(value).strip()
+    if text.isdigit():
+        return convert_unix_ts_to_utc(int(text))
+    try:
+        dt = datetime.fromisoformat(text.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
+
+
+@artifact_processor
+def hyundaiCallHistory(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.db'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT _id, given_name, family_name, phone_number, calltype, date, date_sort,
+                   duration, numberType
+            FROM bluetooth_callhistory
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((row[0], row[1], row[2], row[3], row[4], _ts(row[5]), _ts(row[6]),
+                              row[7], row[8]))
+        db.close()
+
+    data_headers = ('id', 'given_name', 'family_name', ('phone_number', 'phonenumber'), 'calltype',
+                    ('date', 'datetime'), ('date_sort', 'datetime'), 'duration', 'numberType')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/hyundai_contacts.py
+++ b/scripts/artifacts/hyundai_contacts.py
@@ -1,79 +1,39 @@
-import csv
-import os
-import sqlite3
-import re
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Hyundai Sonata']
-platforms = ['Carplay']
-
-def get_contacts(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        db = open_sqlite_db_readonly(file_found)
-        db_name = os.path.splittext(file_found)
-        cursor = db.cursor()
-                    
-        cursor.execute("SELECT _id from bluetooth_contacts")
-        ids = cursor.fetchall()
-
-        cursor.execute("SELECT given_name from bluetooth_contacts")
-        given_names = cursor.fetchall()
-
-        cursor.execute("SELECT family_name from bluetooth_contacts")
-        family_names = cursor.fetchall()
-
-        cursor.execute("SELECT phone_number from bluetooth_contacts")
-        phone_number = cursor.fetchall()
-
-        ti = []
-        tg = []
-        tf = []
-        tn = []
-
-        i = 0
-        for id in ids:
-            id = str(id)
-            id = re.sub(r'\W+', '', id)
-            ti.append(id)
-
-        for given in given_names:
-            given = str(given)
-            given = re.sub(r'\W+', '', given)
-            tg.append(given)
-        for family in family_names:
-            family = str(family)
-            family = re.sub(r'\W+', '', family)
-            tf.append(family)
-        for number in phone_number:
-            number = str(number)
-            number = re.sub(r'\W+', '', number)
-            tn.append(number)
-        
-        for id in ids:
-            data_list.append((ti[i], tg[i], tf[i], tn[i]))
-            i += 1
-        if db_name[1] == 'db':
-            break
-                    
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Contact Data')
-        report.start_artifact_report(report_folder, f'Contact Data')
-        report.add_script()
-        data_headers = ('ID','given_name', 'family_name', 'phone_number')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Contact Data'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Contact Data found')
-
-__artifacts__ = {
-    "contacts": (
-        "contacts",
-        ('*/bluetooth/DB_BMS/MC_*.db*'),
-        get_contacts),
+__artifacts_v2__ = {
+    "hyundaiContacts": {
+        "name": "Hyundai - Contacts",
+        "description": "Bluetooth contacts from a Hyundai infotainment MC_*.db.",
+        "author": "Nixy Camacho",
+        "version": "0.2",
+        "creation_date": "2023-06-09",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Hyundai Vehicles",
+        "notes": "Rewritten as a single query (the original ran separate SELECTs and crashed on "
+                 "os.path.splittext).",
+        "paths": ('*/bluetooth/DB_BMS/MC_*.db*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def hyundaiContacts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.db'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('SELECT _id, given_name, family_name, phone_number FROM bluetooth_contacts')
+        for row in cursor.fetchall():
+            data_list.append((row[0], row[1], row[2], row[3]))
+        db.close()
+
+    data_headers = ('ID', 'given_name', 'family_name', ('phone_number', 'phonenumber'))
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/hyundai_devices.py
+++ b/scripts/artifacts/hyundai_devices.py
@@ -1,61 +1,48 @@
-import csv
-import os
+__artifacts_v2__ = {
+    "hyundaiDevices": {
+        "name": "Hyundai - Bluetooth Devices",
+        "description": "Bluetooth device MAC addresses and friendly names from a Hyundai "
+                       "wireless_dev_list.dat.",
+        "author": "Nixy Camacho",
+        "version": "0.2",
+        "creation_date": "2023-06-09",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Hyundai Vehicles",
+        "notes": "",
+        "paths": ('*/wireless_dev_list.dat',),
+        "output_types": "standard",
+        "artifact_icon": "bluetooth",
+    }
+}
+
 import re
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
+from scripts.ilapfuncs import artifact_processor
 
-#Compatability Data
-vehicles = ['Hyundai Sonata']
-platforms = ['Carplay']
+_ADDR_RE = re.compile(r"[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+:"
+                      r"[A-Za-z0-9]+", re.IGNORECASE)
 
-def get_devices(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def hyundaiDevices(context):
     data_list = []
-    for file_found in files_found:
-        devAddr = []
-        devFriendlyName = []
-        with open(file_found, 'r') as f:
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        dev_addr, dev_name = [], []
+        with open(file_found, 'r', encoding='latin-1') as f:
             for line in f:
-                line_str = str(line)
-                line_str_2 = line_str # Copy of line 
+                text_only = _ADDR_RE.sub('~~~', line).split('~~~')
+                if len(text_only) == 1:
+                    name = text_only[0].strip().strip('\x00').strip('\x01').strip('\x02')
+                    if name and name not in dev_name:
+                        dev_name.append(name)
+                addrs = _ADDR_RE.findall(line)
+                if len(addrs) == 1 and addrs[0] not in dev_addr:
+                    dev_addr.append(addrs[0])
+        data_list.extend(zip(dev_addr, dev_name))
 
-                #Pattern to find addresses
-                addrPattern = re.compile(r"[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+:[A-Za-z0-9]+", re.IGNORECASE)
-
-                #Given pattern, remove from copy of line to find only text
-                line_str_2 = re.sub(addrPattern, '~~~', line_str_2)
-                devFriendlyName_temp = line_str_2.split('~~~')
-                if len(devFriendlyName_temp) == 1: # don't add garbage values to name list
-                    #logfunc("Bytes of devFriendlyName_temp[0]: \n\t" + str(devFriendlyName_temp))
-                    devFriendlyName_temp[0] = str(devFriendlyName_temp[0]).strip().strip('\x00').strip('\x01').strip('\x02')
-                    if devFriendlyName_temp[0] not in devFriendlyName:
-                        devFriendlyName.append(devFriendlyName_temp[0]) # add to name list
-                        #logfunc("devFriendlyName_temp: " + devFriendlyName_temp[0])
-
-                #Get addresses from pattern in given line
-                result = re.findall(addrPattern, line_str)
-                if len(result) == 1:
-                    if result[0] not in devAddr:
-                        devAddr.append(result[0])
-                        #logfunc("Address result: " + str(result[0]))
-
-                data_list = tuple(zip(devAddr, devFriendlyName))
-
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Bluetooth Devices')
-        report.start_artifact_report(report_folder, f'Bluetooth Devices')
-        report.add_script()
-        data_headers = ('Bluetooth MAC Address','Device Friendly Name')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Bluetooth Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Bluetooth Devices found')
-
-__artifacts__ = {
-    "connected devices": (
-        "connected devices",
-        ('*/wireless_dev_list.dat'),
-        get_devices),
-}
+    data_headers = ('Bluetooth MAC Address', 'Device Friendly Name')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/hyundai_infotainment.py
+++ b/scripts/artifacts/hyundai_infotainment.py
@@ -1,41 +1,37 @@
-import csv
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['Hyundai Sonata']
-platforms = ['Carplay']
-
-def get_infotainmentData(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-        with open(file_found, 'r') as f:
-            lines = f.readlines()
-            for line in lines:
-                if "]" in line or "[" in line:
-                    pass
-                else:
-                    splits = line.split("=")
-                    if len(splits) == 2:
-                        data_list.append((splits[0], splits[1]))
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Infotainment Data')
-        report.start_artifact_report(report_folder, f'Infotainment Data')
-        report.add_script()
-        data_headers = ('ID','Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Infotainment Data'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Infotainment Data found')
-
-
-__artifacts__ = {
-    "Accessory Data Hyundai": (
-        "Accessory Data Hyundai",
-        ('*/wifi/settings'),
-        get_infotainmentData),
+__artifacts_v2__ = {
+    "hyundaiInfotainment": {
+        "name": "Hyundai - Infotainment Data",
+        "description": "Infotainment/wifi settings (key=value) from a Hyundai wifi/settings file.",
+        "author": "Nixy Camacho",
+        "version": "0.2",
+        "creation_date": "2023-06-09",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Hyundai Vehicles",
+        "notes": "",
+        "paths": ('*/wifi/settings',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def hyundaiInfotainment(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8', errors='backslashreplace') as f:
+            for line in f:
+                if "[" in line or "]" in line:
+                    continue
+                splits = line.split("=")
+                if len(splits) == 2:
+                    data_list.append((splits[0].strip(), splits[1].strip()))
+
+    data_headers = ('ID', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts four Hyundai (Sonata) artifacts to the full `@artifact_processor` + context-form + LAVA pattern. (`telematicsHyundai`, which emits **seven** reports, follows in its own PR.)

## Artifacts
| Module | Name | Source |
|---|---|---|
| `hyundaiCallHistory` | Hyundai - Call History | `bluetooth/DB_BMS/CH_*.db` |
| `hyundaiContacts` | Hyundai - Contacts | `bluetooth/DB_BMS/MC_*.db` |
| `hyundaiDevices` | Hyundai - Bluetooth Devices | `wireless_dev_list.dat` |
| `hyundaiInfotainment` | Hyundai - Infotainment Data | `wifi/settings` |

## 🐞 Bug fixes
- **`hyundaiCallHistory`** and **`hyundaiContacts`** called `os.path.splittext` (typo for `splitext`) and would **crash**. Both are rewritten as a **single SELECT** over all columns instead of one SELECT per column zipped together — which also drops the per-value `re.sub(r'\W+','')` mangling and returns clean values.

## LAVA specifics
- `hyundaiCallHistory`: `date` / `date_sort` → aware-UTC (`convert_unix_ts_to_utc`), typed datetime; `phone_number` tagged `phonenumber`.
- `hyundaiContacts`: `phone_number` tagged `phonenumber`.
- `"Hyundai - Bluetooth Devices"` avoids colliding with the existing "Bluetooth Devices" name; the `.dat` is read as latin-1 to tolerate binary.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit (all 4 tables): clean.
- Real-sqlite round-trips (call history dates → UTC, phones typed) + text parsers (devices MAC/name, infotainment key=value).
- `PluginLoader` loads all four.

`creation_date` = each original's date (2023-06-09); `last_update_date` = conversion. Attribution preserved (Nixy Camacho).