### PR TITLE
Convert Hyundai telematics to LAVA @artifact_processor (7 artifacts)

### DIFF
--- a/scripts/artifacts/telematicsHyundai.py
+++ b/scripts/artifacts/telematicsHyundai.py
@@ -1,212 +1,176 @@
+__artifacts_v2__ = {
+    "hyundaiTelematicsGps": {
+        "name": "Hyundai - Telematics GPS Detail",
+        "description": "GPS Detail parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'], "artifact_icon": "map-pin",
+    },
+    "hyundaiTelematicsWdw": {
+        "name": "Hyundai - Telematics WdwStatus",
+        "description": "WdwStatus parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'], "artifact_icon": "map-pin",
+    },
+    "hyundaiTelematicsWeather": {
+        "name": "Hyundai - Telematics Weather Waypoint",
+        "description": "Weather waypoints parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": "standard", "artifact_icon": "cloud",
+    },
+    "hyundaiTelematicsEngineIdle": {
+        "name": "Hyundai - Telematics Engine Idle Alarm",
+        "description": "Engine idle alarm events parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": "standard", "artifact_icon": "alert-circle",
+    },
+    "hyundaiTelematicsDriving": {
+        "name": "Hyundai - Telematics Driving Events",
+        "description": "Driving events parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": "standard", "artifact_icon": "navigation",
+    },
+    "hyundaiTelematicsCan": {
+        "name": "Hyundai - Telematics CAN Events",
+        "description": "CAN bus events parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": "standard", "artifact_icon": "cpu",
+    },
+    "hyundaiTelematicsProvisioning": {
+        "name": "Hyundai - Telematics Provisioning",
+        "description": "Provisioning records (VIN/MDM/MIN) parsed from a Hyundai telematics.log.",
+        "author": "@AlexisBrignoni", "version": "0.2", "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Hyundai Vehicles",
+        "notes": "", "paths": ('*/telematics.log*',),
+        "output_types": "standard", "artifact_icon": "key",
+    },
+}
+
 import os
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor
 
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, kmlgen, logdevinfo, is_platform_windows
+def _ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
+    try:
+        dt = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt.astimezone(timezone.utc)
+    except ValueError:
+        return value
 
-#Compatability Data
-vehicles = ['Hyundai Santa Fe',]
-platforms = ['Android Automotive',]
 
-def get_telematicsHyundai(files_found, report_folder, seeker, wrap_text):
-    initLastGpsDetail = []
-    wdwStatus = []
-    weatherWaypoint = []
-    EngineIdleAlarmTask = []
-    driving = []
-    Provisioning = []
-    can = []
-    for file_found in files_found:
+def _parse(context):
+    sections = {'gps': [], 'wdw': [], 'weather': [], 'engine': [], 'driving': [], 'can': [],
+                'prov': []}
+    source_path = ''
+    for file_found in context.get_files_found():
         file_found = str(file_found)
-        
-        with open(file_found, 'r') as f:
-            lines = f.readlines()
-            filename = os.path.basename(file_found)
-            location = os.path.dirname(file_found)
-            for line in lines:
-                #print(line)
+        source_path = file_found
+        filename = os.path.basename(file_found)
+        with open(file_found, encoding='utf-8', errors='backslashreplace') as f:
+            for line in f:
                 if line.startswith(' <Boot'):
                     continue
-                else:
-                    timestamp = line.split(' ', 2)
-                    timestamp = f"XXXX-{timestamp[0]} {timestamp[1]}"
-                    
+                line = line.rstrip('\n')
+                parts = line.split(' ', 2)
+                if len(parts) < 2:
+                    continue
+                timestamp = f"XXXX-{parts[0]} {parts[1]}"
+                try:
                     if 'initLastGpsDetail' in line:
-                        splits = line.split(' ')
-                        speed = (splits[18].split('Speed:')[1])
-                        head = ((splits[18].split('Speed:')[0].split('Head:')[1]))
-                        latitude = (splits[15])
-                        longitude = (splits[16].split(':')[1])
-                        altitude = (splits[17].split(':')[1])
-                        time = (splits[19].split(':')[1])
-                        year = time[0:4]
-                        month = time[4:6]
-                        day = time[6:8]
-                        hour = time[8:10]
-                        minute = time[10:12]
-                        seconds = time[12::]
-                        fecha = f'{year}-{month}-{day} {hour}:{minute}:{seconds}'
-                        offset = (splits[20].split(':')[1])
-                        
-                        initLastGpsDetail.append((timestamp,fecha,offset,latitude,longitude,head,speed,filename))
-                        
-                    if 'wdwStatus' in line:
-                        splits = line.split(' ')
-                        descriptor = (splits[13])
-                        latitude = (splits[16].split()[4])
-                        longitude = (splits[16].split()[5])
-                        
-                        wdwStatus.append((timestamp,descriptor,latitude,longitude))
-                        
-                    if 'Address_name' in line:
-                        add1 = (line.split('Address_name :')[1].split(',',2)[0])
-                        add2 = (line.split('Address_name :')[1].split(',',2)[1])
-                        add = f'{add1} {add2}'
-                        
-                        weatherWaypoint.append((timestamp,add))
-                        
-                    if 'EngineIdleAlarmTask' in line:
-                        event = (line.split('[EngineIdleAlarmTask] ')[1])
-                        
-                        EngineIdleAlarmTask.append((timestamp,event))
-                        
-                    if '[DRIVING] ' in line:
-                        event = (line.split('[DRIVING]')[1])
-                        
-                        driving.append((timestamp,event))
-                        
-                        
-                    if '[Provisioning]' in line:
-                        event = (line.split(' '))
-                        
-                        vin = (event[15].split(':')[1])
-                        mdn = (event[16].split(':')[1])
-                        min = (event[17].split(':')[1])
-                        
-                        Provisioning.append((timestamp,vin,mdn,min))
-                        
-                    if '[CAN]' in line:
-                        event = line.split('[CAN]')[1]
-                        
-                        can.append((timestamp,event))
-                    
-            
-    if len(initLastGpsDetail) > 0:
-        report = ArtifactHtmlReport('GPS Detail')
-        report.start_artifact_report(report_folder, f'GPS Detail')
-        report.add_script()
-        data_headers = ('Timestamp','Date','Date Offset','Latitude','Longitude','Head','Speed','Source')
-        report.write_artifact_data_table(data_headers, initLastGpsDetail, location)
-        report.end_artifact_report()
-        
-        tsvname = f'GPS Detail'
-        tsv(report_folder, data_headers, initLastGpsDetail, tsvname)
-        
-        kmlactivity = 'GPS Detail'
-        kmlgen(report_folder, kmlactivity, initLastGpsDetail, data_headers)
-        
-        
-    else:
-        logfunc(f'No GPS Detail data available')
-    
-    
-    if len(wdwStatus) > 0:
-        report = ArtifactHtmlReport('WdwStatus Report')
-        report.start_artifact_report(report_folder, f'WdwStatus Report')
-        report.add_script()
-        data_headers = ('Timestamp','Descriptor','Latitude','Longitude')
-        report.write_artifact_data_table(data_headers, wdwStatus, location)
-        report.end_artifact_report()
-        
-        tsvname = f'WdwStatus Report'
-        tsv(report_folder, data_headers, wdwStatus, tsvname)
-        
-        kmlactivity = 'WdwStatus Report'
-        kmlgen(report_folder, kmlactivity, wdwStatus, data_headers)
-        
-    else:
-        logfunc(f'No WdwStatus Report data available')
-        
-    
-    if len(weatherWaypoint) > 0:
-        report = ArtifactHtmlReport('WeatherWaypoint Address')
-        report.start_artifact_report(report_folder, f'WeatherWaypoint Address')
-        report.add_script()
-        data_headers = ('Timestamp','Address')
-        report.write_artifact_data_table(data_headers, weatherWaypoint, location)
-        report.end_artifact_report()
-        
-        tsvname = f'WeatherWaypoint Address'
-        tsv(report_folder, data_headers, weatherWaypoint, tsvname)
-        
-    else:
-        logfunc(f'No WeatherWaypoint Report data available')
-        
-
-    if len(EngineIdleAlarmTask) > 0:
-        report = ArtifactHtmlReport('EngineIdleAlarmTask Events')
-        report.start_artifact_report(report_folder, f'EngineIdleAlarmTask Events')
-        report.add_script()
-        data_headers = ('Timestamp','Events')
-        report.write_artifact_data_table(data_headers, EngineIdleAlarmTask, location)
-        report.end_artifact_report()
-        
-        tsvname = f'EngineIdleAlarmTask Address'
-        tsv(report_folder, data_headers, EngineIdleAlarmTask, tsvname)
-        
-    else:
-        logfunc(f'No EngineIdleAlarmTask Report data available')
-        
-        
-    if len(driving) > 0:
-        report = ArtifactHtmlReport('Driving Events')
-        report.start_artifact_report(report_folder, f'Driving Events')
-        report.add_script()
-        data_headers = ('Timestamp','Events')
-        report.write_artifact_data_table(data_headers, driving, location)
-        report.end_artifact_report()
-        
-        tsvname = f'Driving Events'
-        tsv(report_folder, data_headers, driving, tsvname)
-        
-    else:
-        logfunc(f'No Driving Report data available')
-        
-    
-    if len(can) > 0:
-        report = ArtifactHtmlReport('CAN Events')
-        report.start_artifact_report(report_folder, f'CAN Events')
-        report.add_script()
-        data_headers = ('Timestamp','Events')
-        report.write_artifact_data_table(data_headers, can, location)
-        report.end_artifact_report()
-        
-        tsvname = f'CAN Events'
-        tsv(report_folder, data_headers, can, tsvname)
-        
-    else:
-        logfunc(f'No CAN Report data available')
-        
-    
-    if len(can) > 0:
-        report = ArtifactHtmlReport('Provisioning Events')
-        report.start_artifact_report(report_folder, f'Provisioning Events')
-        report.add_script()
-        data_headers = ('Timestamp','VIN','MDM','MIN')
-        report.write_artifact_data_table(data_headers, Provisioning, location)
-        report.end_artifact_report()
-        
-        tsvname = f'Provisioning Events'
-        tsv(report_folder, data_headers, Provisioning, tsvname)
-        
-    else:
-        logfunc(f'No Provisioning Report data available')
-        
+                        s = line.split(' ')
+                        speed = s[18].split('Speed:')[1]
+                        head = s[18].split('Speed:')[0].split('Head:')[1]
+                        latitude = s[15]
+                        longitude = s[16].split(':')[1]
+                        offset = s[20].split(':')[1]
+                        t = s[19].split(':')[1]
+                        fecha = f'{t[0:4]}-{t[4:6]}-{t[6:8]} {t[8:10]}:{t[10:12]}:{t[12:]}'
+                        sections['gps'].append((timestamp, _ts(fecha), offset, latitude, longitude,
+                                                head, speed, filename))
+                    elif 'wdwStatus' in line:
+                        s = line.split(' ')
+                        sections['wdw'].append((timestamp, s[13], s[16].split()[4],
+                                                s[16].split()[5]))
+                    elif 'Address_name' in line:
+                        addr = line.split('Address_name :')[1].split(',', 2)
+                        sections['weather'].append((timestamp, f'{addr[0]} {addr[1]}'))
+                    elif 'EngineIdleAlarmTask' in line:
+                        sections['engine'].append((timestamp,
+                                                   line.split('[EngineIdleAlarmTask] ')[1].strip()))
+                    elif '[DRIVING] ' in line:
+                        sections['driving'].append((timestamp, line.split('[DRIVING]')[1].strip()))
+                    elif '[Provisioning]' in line:
+                        e = line.split(' ')
+                        sections['prov'].append((timestamp, e[15].split(':')[1],
+                                                 e[16].split(':')[1], e[17].split(':')[1]))
+                    elif '[CAN]' in line:
+                        sections['can'].append((timestamp, line.split('[CAN]')[1].strip()))
+                except (IndexError, ValueError):
+                    continue
+    return sections, source_path
 
 
-__artifacts__ = {
-        "Telematics": (
-                "Telematics",
-                ('*/telematics.log*'),
-                get_telematicsHyundai)
-}
+@artifact_processor
+def hyundaiTelematicsGps(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', ('Date', 'datetime'), 'Date Offset', 'Latitude', 'Longitude',
+                    'Head', 'Speed', 'Source')
+    return data_headers, sections['gps'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hyundaiTelematicsWdw(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', 'Descriptor', 'Latitude', 'Longitude')
+    return data_headers, sections['wdw'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hyundaiTelematicsWeather(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', 'Address')
+    return data_headers, sections['weather'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hyundaiTelematicsEngineIdle(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', 'Events')
+    return data_headers, sections['engine'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hyundaiTelematicsDriving(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', 'Events')
+    return data_headers, sections['driving'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hyundaiTelematicsCan(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', 'Events')
+    return data_headers, sections['can'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def hyundaiTelematicsProvisioning(context):
+    sections, source_path = _parse(context)
+    data_headers = ('Timestamp', 'VIN', 'MDM', 'MIN')
+    return data_headers, sections['prov'], context.get_relative_path(source_path)


### PR DESCRIPTION
`telematicsHyundai` parses one `telematics.log` into **seven** different reports, so it splits into seven `@artifact_processor` artifacts (LAVA = one table per artifact), each re-parsing the log via a shared `_parse()` helper.

## Artifacts
| Module | Name | |
|---|---|---|
| `hyundaiTelematicsGps` | Hyundai - Telematics GPS Detail | **KML** |
| `hyundaiTelematicsWdw` | Hyundai - Telematics WdwStatus | **KML** |
| `hyundaiTelematicsWeather` | Hyundai - Telematics Weather Waypoint | |
| `hyundaiTelematicsEngineIdle` | Hyundai - Telematics Engine Idle Alarm | |
| `hyundaiTelematicsDriving` | Hyundai - Telematics Driving Events | |
| `hyundaiTelematicsCan` | Hyundai - Telematics CAN Events | |
| `hyundaiTelematicsProvisioning` | Hyundai - Telematics Provisioning | VIN/MDM/MIN |

## Changes
- `@artifact_processor` + `def fn(context)`; shared `_parse()` returns all seven section lists from a single pass.
- GPS Detail `Date` (from the embedded `YYYYMMDDHHMMSS` field) typed `('Date','datetime')` → UTC; GPS Detail + WdwStatus expose `Latitude`/`Longitude` with `output_types` incl. `'kml'`.
- Per-line field parsing wrapped in `try/except (IndexError, ValueError)` so a malformed line is skipped instead of crashing the whole artifact (the original had no guards).
- Trailing newline stripped so last-field values are clean.

## 🐞 Bug fix
The original gated the **Provisioning** report on `len(can) > 0`, so it only appeared when CAN events also existed. Splitting into independent artifacts removes that coupling.

> Note: the `Timestamp` column carries the log's year-less `XXXX-MM-DD HH:MM:SS` stamp verbatim (left as text); only GPS `Date` has a real year.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit (all 7 tables): clean.
- Functional test: GPS Date→UTC + lat/long, the marker-based sections, and Provisioning (no longer CAN-gated).
- `PluginLoader` loads all seven (total **44**).

`creation_date` = original artifact date (2023-02-08); `last_update_date` = conversion. Attribution preserved (@AlexisBrignoni).