### PR TITLE
Convert Nissan Altima + Nuance VCA contact artifacts to LAVA

### DIFF
--- a/scripts/artifacts/nvcaContacts.py
+++ b/scripts/artifacts/nvcaContacts.py
@@ -1,57 +1,43 @@
-import csv
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Ford Mustang','F-150']
-platforms = ['SYNC3.2V2','SYNCGen3.0_3.0.18093_PRODUCT','SyncGen3_v2_b', 'SYNCGen3.0_1.0.15139_PRODUCT']
-
-def get_nvcaContacts(files_found, report_folder, seeker, wrap_text):
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('.sqlite'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            select 
-            First_Name,
-            Last_Name, 
-            Phone_Number, 
-            Phone_Number_Type
-            from S_Phone_Number_Type, t_phone_number
-            where S_Phone_Number_Type.S_Phone_Number_Type_id = t_phone_number.S_Phone_Number_Type_Id
-            ''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            data_list = []  
-            
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3],))
-                
-                basefile = os.path.basename(file_found)
-                
-                description = 'Nuance VCA Contacts phone numbers.'
-                report = ArtifactHtmlReport('Nuance VCA Contacts')
-                report.start_artifact_report(report_folder, f'{basefile} Contacts', description)
-                report.add_script()
-                data_headers = ('First Name', 'Last Name', 'Phone Number', 'Type')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'{basefile} Contacts'
-                tsv(report_folder, data_headers, data_list, tsvname)
-            else:
-                logfunc('No Nuance VCA Contacts data available')
-
-    
-__artifacts__ = {
-        "NVCA Contacts": (
-                "Contacts",
-                ('*/Nuance/NuanceVCAdb/Phone*.sqlite*'),
-                get_nvcaContacts)
+__artifacts_v2__ = {
+    "nvcaContacts": {
+        "name": "Nuance VCA - Contacts",
+        "description": "Contacts with phone numbers from a Nuance VCA phone database "
+                       "(NuanceVCAdb/Phone*.sqlite).",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2021-07-15",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Nuance VCA",
+        "notes": "",
+        "paths": ('*/Nuance/NuanceVCAdb/Phone*.sqlite*',),
+        "output_types": "standard",
+        "artifact_icon": "user",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def nvcaContacts(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.sqlite'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT First_Name, Last_Name, Phone_Number, Phone_Number_Type
+            FROM S_Phone_Number_Type, t_phone_number
+            WHERE S_Phone_Number_Type.S_Phone_Number_Type_id = t_phone_number.S_Phone_Number_Type_Id
+        ''')
+        for row in cursor.fetchall():
+            data_list.append((row[0], row[1], row[2], row[3]))
+        db.close()
+
+    data_headers = ('First Name', 'Last Name', ('Phone Number', 'phonenumber'), 'Type')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/phoneconfigAltima.py
+++ b/scripts/artifacts/phoneconfigAltima.py
@@ -1,61 +1,43 @@
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, kmlgen, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['Nissan Altima',]
-platforms = ['-',]
-
-def get_phoneconfigAltima(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        data_list = []
-        start = None
-        
-        with open(file_found, 'r') as f:
-            for line in f.readlines():
-                if '[' in line:
-                    start = line.replace('[','')
-                    start = start.replace(']','')
-                    start = start.replace('_',' ')
-                    start = start.strip()
-                    
-                if '=' in line:
-                    splitted = line.split('=')
-                    key = splitted[0]
-                    value = splitted[1]
-                    if value == '\n':
-                        continue
-                    else:
-                        data_list.append((key, value))
-                        
-                if line == '\n':
-                    if start is None:
-                        continue
-                    else:
-                        if len(data_list) > 0:
-                            report = ArtifactHtmlReport(f'Phone Config {start}')
-                            report.start_artifact_report(report_folder, f'Phone Config {start}')
-                            report.add_script()
-                            data_headers = ('Key','Value')
-                            report.write_artifact_data_table(data_headers, data_list, file_found)
-                            report.end_artifact_report()
-                            
-                            tsvname = f'Phone Config {start}'
-                            tsv(report_folder, data_headers, data_list, tsvname)
-                            
-                        else:
-                            logfunc(f'No Phone Config {start} data available')
-                        
-                        data_list = []
-
-
-__artifacts__ = {
-        "phoneConfig": (
-                "Phone Config",
-                ('*/ffs/phone_config.dat'),
-                get_phoneconfigAltima)
+__artifacts_v2__ = {
+    "phoneConfigAltima": {
+        "name": "Nissan - Phone Config",
+        "description": "Phone configuration (INI-style key/value sections) from a Nissan Altima "
+                       "ffs/phone_config.dat.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2023-02-13",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Nissan Vehicles",
+        "notes": "The original emitted one report per [section]; the sections are flattened into a "
+                 "single table with a Section column (a fixed LAVA table can't have a "
+                 "per-file-variable number of sub-reports).",
+        "paths": ('*/ffs/phone_config.dat',),
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def phoneConfigAltima(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        section = ''
+        with open(file_found, 'r', encoding='utf-8', errors='backslashreplace') as f:
+            for line in f:
+                if '[' in line:
+                    section = line.replace('[', '').replace(']', '').replace('_', ' ').strip()
+                elif '=' in line:
+                    key, _, value = line.partition('=')
+                    value = value.strip()
+                    if value:
+                        data_list.append((section, key.strip(), value))
+
+    data_headers = ('Section', 'Key', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/phonedbAltima.py
+++ b/scripts/artifacts/phonedbAltima.py
@@ -1,86 +1,58 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import timeline, tsv, logfunc, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Nissan Altima',]
-platforms = []
-
-def get_phonedbAltima(files_found, report_folder, seeker, wrap_text):
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('phone_db.db'):
-            break
-            
-    db = open_sqlite_db_readonly(file_found)
-    cursor = db.cursor()
-    cursor.execute('''
-        SELECT 
-        NAME 
-        FROM SQLITE_SCHEMA
-        WHERE NAME LIKE 'NUM_PHONEBOOK%'
-        order by name
-    ''')
-
-    all_rows = cursor.fetchall()
-    usageentries = len(all_rows)
-    
-    
-    if usageentries > 0:
-        for row in all_rows:
-            data_list = []
-            data_list_as_is = []
-            
-            tablename = (row[0])
-            tablenamenum = tablename.split('_')[2]
-            
-            cursor.execute(f''' 
-            SELECT
-            num_phonebook_{tablenamenum}.entry_id,
-            phonebook_{tablenamenum}.first_name,
-            phonebook_{tablenamenum}.last_name,
-            GROUP_CONCAT(num_phonebook_{tablenamenum}.number, '; ')
-            from num_phonebook_{tablenamenum}
-            join phonebook_{tablenamenum} where num_phonebook_{tablenamenum}.entry_id = phonebook_{tablenamenum}.entry_id
-            group by num_phonebook_{tablenamenum}.entry_id
-            ''')
-            
-            all_rows_inner = cursor.fetchall()
-            usageentries_inner = len(all_rows_inner)
-            
-            if usageentries_inner > 0:
-                for rows_inner in all_rows_inner:
-                    data_list.append((rows_inner[0], rows_inner[1], rows_inner[2], rows_inner[3].replace(';', '<br>')))
-                    data_list_as_is.append((rows_inner[0], rows_inner[1], rows_inner[2], rows_inner[3]))
-                    
-                description = 'Phone Book Contactrs'
-                report = ArtifactHtmlReport(f'Phone Book {tablenamenum} Contacts')
-                report.start_artifact_report(report_folder, f'Phone Book {tablenamenum} Contacts', description)
-                report.add_script()
-                data_headers = ('ID', 'First Name', 'Last Name', 'Phone Number/s')
-                report.write_artifact_data_table(data_headers, data_list, file_found, html_no_escape=['Phone Number/s'])
-                report.end_artifact_report()
-                
-                tsvname = f'Phone Book Information {tablenamenum}'
-                tsv(report_folder, data_headers, data_list_as_is, tsvname)
-                
-            else:
-                logfunc(f'No Phone Book {tablenamenum} Contacts data available')
-                
-    else:
-        logfunc('No Phone Book contacts data available')
-    
-
-
-__artifacts__ = {
-        "Phone Book": (
-                "Phone Book DB",
-                ('*/ffs/phone_db.db*'),
-                get_phonedbAltima)
+__artifacts_v2__ = {
+    "phoneBookAltima": {
+        "name": "Nissan - Phone Book Contacts",
+        "description": "Phonebook contacts (per paired device) from a Nissan Altima "
+                       "ffs/phone_db.db.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2023-02-14",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Nissan Vehicles",
+        "notes": "The DB holds one phonebook per paired device (NUM_PHONEBOOK_<n>/phonebook_<n>); "
+                 "the original emitted one report per phonebook, here flattened into a single "
+                 "table with a Phone Book column. Phone Number/s is a '; '-joined list.",
+        "paths": ('*/ffs/phone_db.db*',),
+        "output_types": "standard",
+        "artifact_icon": "book",
+    }
 }
-        
-        
+
+import sqlite3
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def phoneBookAltima(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('phone_db.db'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute("SELECT NAME FROM SQLITE_SCHEMA WHERE NAME LIKE 'NUM_PHONEBOOK%' "
+                       "ORDER BY name")
+        for (tablename,) in cursor.fetchall():
+            num = tablename.split('_')[2]
+            try:
+                cursor.execute(f'''
+                    SELECT num_phonebook_{num}.entry_id, phonebook_{num}.first_name,
+                           phonebook_{num}.last_name,
+                           GROUP_CONCAT(num_phonebook_{num}.number, '; ')
+                    FROM num_phonebook_{num}
+                    JOIN phonebook_{num}
+                      ON num_phonebook_{num}.entry_id = phonebook_{num}.entry_id
+                    GROUP BY num_phonebook_{num}.entry_id
+                ''')
+            except sqlite3.Error:
+                continue
+            for row in cursor.fetchall():
+                data_list.append((num, row[0], row[1], row[2], row[3]))
+        db.close()
+
+    data_headers = ('Phone Book', 'ID', 'First Name', 'Last Name', 'Phone Number/s')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts three v1 artifacts to the full `@artifact_processor` + context-form + LAVA pattern.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `phoneConfigAltima` | Nissan - Phone Config | `ffs/phone_config.dat` |
| `phoneBookAltima` | Nissan - Phone Book Contacts | `ffs/phone_db.db` |
| `nvcaContacts` | Nuance VCA - Contacts | `NuanceVCAdb/Phone*.sqlite` |

## Dynamic-report flattening
A LAVA artifact is **one fixed table**, so the originals' per-file-variable number of sub-reports can't be preserved as separate tables:
- **`phoneConfigAltima`** — the original emitted one report per `[section]`; sections are flattened into one table with a **Section** column.
- **`phoneBookAltima`** — the DB holds one phonebook per paired device (`NUM_PHONEBOOK_<n>`/`phonebook_<n>`); the original emitted one report per phonebook, here flattened into one table with a **Phone Book** column. The per-table dynamic SQL is preserved and wrapped in `try/except sqlite3.Error`; `Phone Number/s` stays a `'; '`-joined list (text).

## Other
- **`nvcaContacts`** — `Phone Number` tagged `('Phone Number','phonenumber')`; it is a Nuance VCA database, so categorized **"Nuance VCA"** (not Nissan).
- `phoneConfig` uses `str.partition('=')` so values containing `=` are preserved.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit (all 3 tables): clean.
- Real-sqlite round-trips: phonedb across two `NUM_PHONEBOOK` tables with GROUP_CONCAT numbers; nvca phone typed; phoneconfig INI → Section column.
- `PluginLoader` loads all three.

`creation_date` = each original's date; `last_update_date` = conversion. Attribution preserved (@AlexisBrignoni).