### PR TITLE
Convert misc vehicle artifacts to LAVA @artifact_processor

### DIFF
--- a/scripts/artifacts/dipoAudio.py
+++ b/scripts/artifacts/dipoAudio.py
@@ -1,47 +1,38 @@
-import xml.etree.ElementTree as ET
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
-
-#Compatability Data
-vehicles = ['Hyundai Santa Fe',]
-platforms = ['Android Automotive',]
-
-def get_dipoAudio(files_found, report_folder, seeker, wrap_text):
-    data_list = []
-    for file_found in files_found:
-
-        tree = ET.parse(file_found)
-        root = tree.getroot()
-        
-        for elem in root:
-            name = (elem.attrib['name'])
-            if name == 'pref_key_local_bt_address':
-                text = elem.text
-            else:
-                text = ''
-            data_list.append((name,text))
-            
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Audio UUIDs')
-        report.start_artifact_report(report_folder, f'Audio UUIDs')
-        report.add_script()
-        data_headers = ('UUID','Extra Value')
-        #file_found = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Audio UUIDs'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc(f'No Audio UUIDs available')
-
-
-__artifacts__ = {
-        "dipoAudio": (
-                "Audio UUIDs",
-                ('*/com.daudio.app.dipo/shared_prefs/pref_dipo.xml'),
-                get_dipoAudio)
+__artifacts_v2__ = {
+    "dipoAudio": {
+        "name": "Hyundai - Dipo Audio UUIDs",
+        "description": "Audio app preference UUIDs (incl. local BT address) from a Hyundai Santa Fe "
+                       "com.daudio.app.dipo pref_dipo.xml.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2023-02-08",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Hyundai Vehicles",
+        "notes": "",
+        "paths": ('*/com.daudio.app.dipo/shared_prefs/pref_dipo.xml',),
+        "output_types": "standard",
+        "artifact_icon": "music",
+    }
 }
+
+import xml.etree.ElementTree as ET
+
+from scripts.ilapfuncs import artifact_processor
+
+
+@artifact_processor
+def dipoAudio(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        root = ET.parse(file_found).getroot()
+        for elem in root:
+            name = elem.attrib.get('name', '')
+            text = elem.text if name == 'pref_key_local_bt_address' else ''
+            data_list.append((name, text))
+
+    data_headers = ('UUID', 'Extra Value')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/logparser.py
+++ b/scripts/artifacts/logparser.py
@@ -1,79 +1,56 @@
-import csv
-import os
-import re
-import tarfile
-import datetime
-from pathlib import Path
+__artifacts_v2__ = {
+    "logparser": {
+        "name": "RAM - GPS Locations from Logs",
+        "description": "GPS locations (KONA-LIB LocationDistributor) parsed from RAM 1500 "
+                       "persistent logs.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2024-04-06",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "RAM Vehicles",
+        "notes": "Timestamp is the log's epoch normalized to UTC. Latitude/Longitude exposed for "
+                 "the KML map. (Shares the persistentLogs/*/Log* path with the Chrysler Location "
+                 "Logs artifact; each only matches its own log lines.)",
+        "paths": ('*/persistentLogs/*/Log*',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    }
+}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, kmlgen, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
 
-#Compatability Data
-vehicles = ['RAM 1500']
-platforms = []
- 
-def timeorder(line):
-    month = line.split('/', 3)[0]
-    day = line.split('/', 3)[1]
-    yeartime = line.split('/', 3)[2]
-    year = yeartime.split(' ')[0]
-    time = yeartime.split(' ')[1]
-    timestamp = f'{year}-{month}-{day} {time}'
-    return timestamp
+_MARKER = '[INFO] LocationDistributor[KONA-LIB] Location details: '
 
-def get_logparser(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def logparser(context):
     data_list = []
-    
-    for file_found in files_found:
-        #logfunc(' ')
-        #logfunc(file_found)
-        basename = os.path.basename(file_found)
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        basename = file_found.rsplit('/', 1)[-1]
+        source_path = file_found
         with open(file_found, 'r', encoding='cp437') as f:
             for line in f:
-                if '[INFO] LocationDistributor[KONA-LIB] Location details: ' in line:
-                    linesplit = line.split('[INFO] LocationDistributor[KONA-LIB] Location details: ')[1]
-                    linesplit = linesplit.split(';')
-                    latitude = linesplit[1].split(' ')[2]
-                    longitude = linesplit[2].split(' ')[2]
-                    altitude = linesplit[4].split(' ')[2]
-                    horzac = linesplit[5].split(' ')[3]
-                    vertac = linesplit[6].split(' ')[3]
-                    times = linesplit[7].split(' ')[3]
-                    times = int(times)
-                    times = datetime.datetime.utcfromtimestamp(times).strftime('%Y-%m-%d %H:%M:%S')
-                    course = linesplit[8].split(' ')[2]
-                    speed = linesplit[9].split(' ')[2]
-                    azimuth = linesplit[10].split(' ')[2]
-                    locm = linesplit[11].split(' ')[3]
-                    
-                    data_list.append((times, latitude, longitude, horzac, vertac, altitude, course, speed, azimuth, basename))
-                    
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('GPS Locations from Logs')
-        report.start_artifact_report(report_folder, f'GPS Locations from Logs')
-        report.add_script()
-        data_headers_dev = ('Timestamp','Latitude','Longitude', 'Horizontal Accuracy', 'Vertical Accuracy', 'Altitude', 'Course', 'Speed', 'Azimuth', 'Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_dev, data_list, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'GPS Locations from Logs'
-        tsv(report_folder, data_headers_dev , data_list, tsvname)
-        
-        tlactivity = 'GPS Locations from Logs'
-        timeline(report_folder, tlactivity, data_list, data_headers_dev)
-        
-        kmlactivity = 'GPS Locations from Logs'
-        kmlgen(report_folder, kmlactivity, data_list, data_headers_dev)
-        
-    else:
-        logfunc(f'No GPS Locations from Logs results available')
-        
-    
-        
-__artifacts__ = {
-        "logparser": (
-                "logparser",
-                ('*/persistentLogs/*/Log*'),
-                get_logparser)
-}
+                if _MARKER not in line:
+                    continue
+                try:
+                    parts = line.split(_MARKER)[1].split(';')
+                    latitude = parts[1].split(' ')[2]
+                    longitude = parts[2].split(' ')[2]
+                    altitude = parts[4].split(' ')[2]
+                    horzac = parts[5].split(' ')[3]
+                    vertac = parts[6].split(' ')[3]
+                    times = convert_unix_ts_to_utc(int(parts[7].split(' ')[3]))
+                    course = parts[8].split(' ')[2]
+                    speed = parts[9].split(' ')[2]
+                    azimuth = parts[10].split(' ')[2]
+                except (IndexError, ValueError):
+                    continue
+                data_list.append((times, latitude, longitude, horzac, vertac, altitude, course,
+                                  speed, azimuth, basename))
+
+    data_headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Horizontal Accuracy',
+                    'Vertical Accuracy', 'Altitude', 'Course', 'Speed', 'Azimuth', 'Log Filename')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/mediaService.py
+++ b/scripts/artifacts/mediaService.py
@@ -1,77 +1,53 @@
-import sqlite3
-import os
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
-
-#Compatability Data
-vehicles = ['Ford']
-platforms = ['SYNC3.1','SYNCGen3']
-
-def get_mediaService(files_found, report_folder, seeker, wrap_text):
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        if file_found.endswith('mediaservice_db'):
-            db = open_sqlite_db_readonly(file_found)
-            cursor = db.cursor()
-            cursor.execute('''
-            select
-            mediastores.btdeviceid as "BT Device ID",
-            mediastores.serial as "Serial",
-            mediastores.device_id as "Device ID",
-            mediastores.manufacturer as "Manufacturer",
-            mediastores.product as "Product",
-            mediastores.device_name as "Device Name",
-            mediastores.vendorid as "Vendor ID",
-            mediastores.productid as "Product ID",
-            Case mediastores.attached
-                when '0' then 'No'
-                when '1' then 'Yes'
-                ELSE 'Not Specified'
-            END as "Device Attached",
-            Case mediastores.active_onshutdown
-                when '0' then 'No'
-                when '1' then 'Yes'
-                ELSE 'Not Specified'
-            END as "Active On Shutdown?",
-            Case mediastores.remote
-                when '0' then 'No'
-                when '1' then 'Yes'
-                ELSE 'Not Specified'
-            END as "Is Remote?",
-            mediastores.fs_type as "FS Type"
-            from mediastores
-            order by mediastores.btdeviceid
-            ''')
-            
-            all_rows = cursor.fetchall()
-            usageentries = len(all_rows)
-            data_list = []  
-            
-            if usageentries > 0:
-                for row in all_rows:
-                    data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6], row[7], row[8], row[9], row[10], row[11]))
-                
-                basefile = os.path.basename(file_found)
-                
-                description = 'Media Service Information'
-                report = ArtifactHtmlReport('Media Service Information')
-                report.start_artifact_report(report_folder, f'Media Service Information', description)
-                report.add_script()
-                data_headers = ('BT Device ID', 'Serial', 'Device ID', 'Manufacturer', 'Product', 'Device Name', 'Vendor ID', 'Product ID', 'Device Attached', 'Active on Shutdown', 'Is Remote', 'FS Type')
-                report.write_artifact_data_table(data_headers, data_list, file_found)
-                report.end_artifact_report()
-                
-                tsvname = f'{basefile} Media Service Information'
-                tsv(report_folder, data_headers, data_list, tsvname)
-            else:
-                logfunc('No Media Service Information data available')
-
-    
-__artifacts__ = {
-        "mediaservice": (
-                "Media Service",
-                ('*/mediaservice_db*'),
-                get_mediaService)
+__artifacts_v2__ = {
+    "mediaService": {
+        "name": "Ford - Media Service",
+        "description": "Connected media-store devices from a Ford SYNC mediaservice_db.",
+        "author": "gforce4n6",
+        "version": "0.2",
+        "creation_date": "2024-03-28",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "",
+        "paths": ('*/mediaservice_db*',),
+        "output_types": "standard",
+        "artifact_icon": "hard-drive",
+    }
 }
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+
+@artifact_processor
+def mediaService(context):
+    data_list = []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('mediaservice_db'):
+            continue
+        source_path = file_found
+        db = open_sqlite_db_readonly(file_found)
+        cursor = db.cursor()
+        cursor.execute('''
+            SELECT mediastores.btdeviceid, mediastores.serial, mediastores.device_id,
+                   mediastores.manufacturer, mediastores.product, mediastores.device_name,
+                   mediastores.vendorid, mediastores.productid,
+                   CASE mediastores.attached WHEN '0' THEN 'No' WHEN '1' THEN 'Yes'
+                        ELSE 'Not Specified' END,
+                   CASE mediastores.active_onshutdown WHEN '0' THEN 'No' WHEN '1' THEN 'Yes'
+                        ELSE 'Not Specified' END,
+                   CASE mediastores.remote WHEN '0' THEN 'No' WHEN '1' THEN 'Yes'
+                        ELSE 'Not Specified' END,
+                   mediastores.fs_type
+            FROM mediastores
+            ORDER BY mediastores.btdeviceid
+        ''')
+        for row in cursor.fetchall():
+            data_list.append(tuple(row))
+        db.close()
+
+    data_headers = ('BT Device ID', 'Serial', 'Device ID', 'Manufacturer', 'Product',
+                    'Device Name', 'Vendor ID', 'Product ID', 'Device Attached',
+                    'Active on Shutdown', 'Is Remote', 'FS Type')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/systemappwtf.py
+++ b/scripts/artifacts/systemappwtf.py
@@ -1,123 +1,104 @@
-import os
-import gzip
-import datetime
-
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, kmlgen, logdevinfo, is_platform_windows, timeline
-
-#Compatability Data
-vehicles = ['Kia Sorrento 2018',]
-platforms = ['Unknown',]
-
-def timestampcalc(timevalue):
-    timestamp = (datetime.datetime.fromtimestamp(int(timevalue)/1000).strftime('%Y-%m-%d %H:%M:%S'))
-    return timestamp
-
-def get_systemappwtf(files_found, report_folder, seeker, wrap_text):
-    data_list_gps = []
-    data_list = []
-    
-    for file_found in files_found:
-        file_found = str(file_found)
-        
-        filename = os.path.basename(file_found)
-        location = os.path.dirname(file_found)
-        
-        if file_found.endswith('.gz'):
-            with gzip.open(file_found, 'rb') as f_in:
-                file = f_in.readlines()
-        else:
-            with open(file_found, 'r', errors='backslashreplace') as f:
-                file = f.readlines()
-                
-        for x in file:
-            if isinstance(x, bytes):
-                x = x.decode()
-                
-            if 'V/GpsLocationProvider' and 'reportLocation' in x:
-                fecha = ' '.join(x.split(' ',2)[:2])
-                limitedlineone = (x.split('reportLocation')[1])
-                gpslatlong = limitedlineone.split('timestamp: ')[0]
-                gpslong = gpslatlong.split('long: ')[1]
-                middle = gpslatlong.split('long: ')[0]
-                gpslat = middle.split('lat: ')[1]
-                timestamp = limitedlineone.split('timestamp: ')[1]
-                timestampfinal = timestampcalc(timestamp)
-                
-                data_list_gps.append((timestampfinal, fecha, gpslat, gpslong, file_found, x))
-                
-            if '[BTCallTracker] ' and 'number=' in x:
-                fecha = ' '.join(x.split(' ',2)[:2])
-                if 'GET_CURRENT_CALLS  'in x:
-                    currentcalls = x.split('GET_CURRENT_CALLS  ')[1]
-                    
-                    numberone = (currentcalls.split(',', 11))[8]
-                    number = (numberone.split('=')[1])
-                    
-                    status = (currentcalls.split(',', 11))[1]
-                    
-                    data_list.append((fecha,number,' ',status,file_found,x))
-                
-                if '[BTCallTracker] poll: conn' and ']=null,' in x:
-                    datacall = x.split(',number=')[1]
-                    number = datacall.split(',')[0]
-                    
-                    datacall = x.split(',toa=')[0]
-                    state = datacall.split(',')[-1]
-                    
-                    data_list.append((fecha,number,' ',state,file_found,x))
-                    
-                elif '[BTCallTracker] poll: conn' in x:
-                    #logfunc(str(x))
-                    datacall = x.split('addr: ')[1]
-                    number = datacall.split(' ',1)[0]
-                    
-                    incoming = (datacall.split(' ',5)[2])
-                    state = (datacall.split(' ',5)[4])
-                    
-                    data_list.append((fecha,number,incoming,state,file_found,x))
-            
-                    
-            
-    if len(data_list_gps) > 0:
-        report = ArtifactHtmlReport('GPS Detail')
-        report.start_artifact_report(report_folder, f'GPS Detail')
-        report.add_script()
-        data_headers_gps = ('Timestamp','Date','Latitude','Longitude','Source','Source Line')
-        report.write_artifact_data_table(data_headers_gps, data_list_gps, location)
-        report.end_artifact_report()
-        
-        tsvname = f'GPS Detail'
-        tsv(report_folder, data_headers_gps, data_list_gps, tsvname)
-        
-        kmlactivity = 'GPS Detail'
-        kmlgen(report_folder, kmlactivity, data_list_gps, data_headers_gps)
-        
-        tlactivity = 'GPS Detail'
-        timeline(report_folder, tlactivity, data_list_gps, data_headers_gps)
-    
-    else:
-        logfunc(f'No GPS Detail data available')
-    
-    
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('BT Call Report')
-        report.start_artifact_report(report_folder, f'BT Call Report')
-        report.add_script()
-        data_headers = ('Date','Phone Number','Incoming','State','Source','Source Line')
-        report.write_artifact_data_table(data_headers, data_list, location)
-        report.end_artifact_report()
-        
-        tsvname = f'BT Call Report'
-        tsv(report_folder, data_headers, data_list, tsvname)
-
-    else:
-        logfunc(f'No BT Call Report data available')
-        
-    
-__artifacts__ = {
-        "BT Report": (
-                "BT Report",
-                ('*/system_app_wtf@*.txt.gz','*/tombstones/tombstone_*','*/system_app_crash@*.txt.gz','*/SYSTEM_TOMBSTONE@*.txt.gz'),
-                get_systemappwtf)
+__artifacts_v2__ = {
+    "systemappwtfGps": {
+        "name": "Kia - System App GPS Detail",
+        "description": "GPS fixes (GpsLocationProvider reportLocation) scraped from Kia "
+                       "system_app_wtf / tombstone logs.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2023-03-27",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Kia Vehicles",
+        "notes": "Timestamp is the GpsLocationProvider millisecond epoch normalized to UTC; Date is "
+                 "the raw log line time. Latitude/Longitude exposed for the KML map.",
+        "paths": ('*/system_app_wtf@*.txt.gz', '*/tombstones/tombstone_*',
+                  '*/system_app_crash@*.txt.gz', '*/SYSTEM_TOMBSTONE@*.txt.gz'),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
+        "artifact_icon": "map-pin",
+    },
+    "systemappwtfBtCalls": {
+        "name": "Kia - System App BT Calls",
+        "description": "Bluetooth call tracker events scraped from Kia system_app_wtf / tombstone "
+                       "logs.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2023-03-27",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Kia Vehicles",
+        "notes": "Date is the raw log line time.",
+        "paths": ('*/system_app_wtf@*.txt.gz', '*/tombstones/tombstone_*',
+                  '*/system_app_crash@*.txt.gz', '*/SYSTEM_TOMBSTONE@*.txt.gz'),
+        "output_types": "standard",
+        "artifact_icon": "phone-call",
+    },
 }
+
+import gzip
+
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+
+def _read_lines(file_found):
+    if file_found.endswith('.gz'):
+        with gzip.open(file_found, 'rb') as f:
+            return [line.decode(errors='backslashreplace') for line in f]
+    with open(file_found, 'r', encoding='utf-8', errors='backslashreplace') as f:
+        return f.readlines()
+
+
+def _parse(context):
+    gps, calls = [], []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        rel = context.get_relative_path(file_found)
+        for x in _read_lines(file_found):
+            fecha = ' '.join(x.split(' ', 2)[:2])
+            if 'V/GpsLocationProvider' in x and 'reportLocation' in x:
+                try:
+                    rest = x.split('reportLocation')[1]
+                    latlong = rest.split('timestamp: ')[0]
+                    gpslong = latlong.split('long: ')[1]
+                    gpslat = latlong.split('long: ')[0].split('lat: ')[1]
+                    ms = x.split('timestamp: ')[1].strip()
+                    gps.append((convert_unix_ts_to_utc(int(ms)), fecha, gpslat.strip(),
+                                gpslong.strip(), rel, x.strip()))
+                except (IndexError, ValueError):
+                    pass
+            if '[BTCallTracker]' in x and 'number=' in x:
+                try:
+                    if 'GET_CURRENT_CALLS  ' in x:
+                        current = x.split('GET_CURRENT_CALLS  ')[1]
+                        number = current.split(',', 11)[8].split('=')[1]
+                        status = current.split(',', 11)[1]
+                        calls.append((fecha, number, ' ', status, rel, x.strip()))
+                    if '[BTCallTracker] poll: conn' in x and ']=null,' in x:
+                        number = x.split(',number=')[1].split(',')[0]
+                        state = x.split(',toa=')[0].split(',')[-1]
+                        calls.append((fecha, number, ' ', state, rel, x.strip()))
+                    elif '[BTCallTracker] poll: conn' in x:
+                        datacall = x.split('addr: ')[1]
+                        number = datacall.split(' ', 1)[0]
+                        incoming = datacall.split(' ', 5)[2]
+                        state = datacall.split(' ', 5)[4]
+                        calls.append((fecha, number, incoming, state, rel, x.strip()))
+                except (IndexError, ValueError):
+                    pass
+    return gps, calls, source_path
+
+
+@artifact_processor
+def systemappwtfGps(context):
+    gps, _, source_path = _parse(context)
+    data_headers = (('Timestamp', 'datetime'), 'Date', 'Latitude', 'Longitude', 'Source',
+                    'Source Line')
+    return data_headers, gps, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def systemappwtfBtCalls(context):
+    _, calls, source_path = _parse(context)
+    data_headers = ('Date', 'Phone Number', 'Incoming', 'State', 'Source', 'Source Line')
+    return data_headers, calls, context.get_relative_path(source_path)

--- a/scripts/artifacts/vehicleInfo.py
+++ b/scripts/artifacts/vehicleInfo.py
@@ -1,59 +1,45 @@
-import csv
-import os
+__artifacts_v2__ = {
+    "vehicleInfo": {
+        "name": "Ford - Vehicle Info",
+        "description": "Vehicle info (name::value pairs: VIN, odometer, fuel level, etc.) from a "
+                       "Ford SYNC ppsp reconn/vehicle file.",
+        "author": "@AlexisBrignoni",
+        "version": "0.2",
+        "creation_date": "2021-07-06",
+        "last_update_date": "2026-06-29",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "",
+        "paths": ('*/ppsp/services/reconn/vehicle',),
+        "output_types": "standard",
+        "artifact_icon": "truck",
+    }
+}
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logdevinfo
 
-#Compatability Data
-vehicles = ['Ford Mustang','F-150']
-platforms = ['SYNC3.2V2','SYNCGen3.0_3.0.18093_PRODUCT','SyncGen3_v2_b', 'SYNCGen3.0_1.0.15139_PRODUCT']
+_DEVINFO = {'fuellevel': 'Fuel Level', 'ignitionstate': 'Ignition State', 'navigation': 'Navigation',
+            'odometer': 'Odometer', 'platform': 'Platform', 'vin': 'VIN from PPSP',
+            'vmcufpn': 'Firmware'}
 
-def get_vehicleInfo(files_found, report_folder, seeker, wrap_text):
+
+@artifact_processor
+def vehicleInfo(context):
     data_list = []
-    for file_found in files_found:
-        with open(file_found, "r") as f:
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
+        with open(file_found, 'r', encoding='utf-8', errors='backslashreplace') as f:
             for line in f:
                 splits = line.split('::')
-                totalvalues = len(splits)
-                if totalvalues > 1:
-                    key = splits[0].strip()
-                    value = splits[1].strip()
-                    if 'DE0' not in splits[0]:
-                        data_list.append((key, value))
-                        
-                        if  key == 'fuellevel' :
-                            logdevinfo(f"Fuel Level: {value}")
-                        if  key == 'ignitionstate' :
-                            logdevinfo(f"Ignition State: {value}")
-                        if  key == 'navigation' :
-                            logdevinfo(f"Navigation: {value}")
-                        if  key == 'odometer' :
-                            logdevinfo(f"Odometer: {value}")
-                        if  key == 'platform' :
-                            logdevinfo(f"Platform: {value}")
-                        if  key == 'vin' :
-                            logdevinfo(f"VIN from PPSP: {value}")
-                        if  key == 'vmcufpn' :
-                            logdevinfo(f"Firmware: {value}")
-            
-    if len(data_list) > 0:
-        report = ArtifactHtmlReport('Vehicle Info')
-        report.start_artifact_report(report_folder, f'Vehicle Info')
-        report.add_script()
-        data_headers = ('Key','Value')
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        
-        tsvname = f'Vehicle Info'
-        tsv(report_folder, data_headers, data_list, tsvname)
-        
-    else:
-        logfunc(f'No Vehicle Info available')
+                if len(splits) < 2 or 'DE0' in splits[0]:
+                    continue
+                key = splits[0].strip()
+                value = splits[1].strip()
+                data_list.append((key, value))
+                if key in _DEVINFO:
+                    logdevinfo(f"{_DEVINFO[key]}: {value}")
 
-
-__artifacts__ = {
-        "Vehicle Info": (
-                "Vehicle Info",
-                ('*/ppsp/services/reconn/vehicle'),
-                get_vehicleInfo)
-}
+    data_headers = ('Key', 'Value')
+    return data_headers, data_list, context.get_relative_path(source_path)


### PR DESCRIPTION
Converts five v1 artifacts to the full `@artifact_processor` + context-form + LAVA pattern.

## Artifacts
| Module | Name | Source |
|---|---|---|
| `mediaService` | Ford - Media Service | `mediaservice_db` |
| `vehicleInfo` | Ford - Vehicle Info | `ppsp reconn/vehicle` |
| `dipoAudio` | Hyundai - Dipo Audio UUIDs | `pref_dipo.xml` |
| `systemappwtfGps` | Kia - System App GPS Detail | system_app_wtf/tombstone → **KML** |
| `systemappwtfBtCalls` | Kia - System App BT Calls | system_app_wtf/tombstone |
| `logparser` | RAM - GPS Locations from Logs | persistentLogs → **KML** |

(`systemappwtf` is one log producing two reports, so it splits into two artifacts.)

## LAVA / timestamps
- `systemappwtfGps`: GpsLocationProvider **millisecond** epoch → aware UTC, typed datetime; Latitude/Longitude + KML.
- `logparser`: log epoch → aware UTC (was `datetime.utcfromtimestamp`, naive); Latitude/Longitude + KML. Shares the `persistentLogs/*/Log*` path with the Chrysler Location Logs artifact — each only matches its own log lines.
- `vehicleInfo` keeps the per-key `logdevinfo` calls and skips `DE0` keys.

## 🐞 Bug fix
`systemappwtf` used `if 'A' and 'B' in x:` in several places, where the non-empty string `'A'` is **always truthy**, so only `'B'` was actually tested (matching far too many lines). Corrected to `'A' in x and 'B' in x`. Field parsing is also wrapped in try/except so a malformed line is skipped rather than crashing.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = **10.00/10**.
- Reserved-word / duplicate-column audit (all 6 tables): clean.
- Functional tests: media-store CASE columns, vehicle `::` + DE0 skip, dipo XML, GPS ms→UTC + KML cols, BT `GET_CURRENT_CALLS` parse, logparser epoch→UTC.
- `PluginLoader` loads all six (total **45**).

`creation_date` = each original's date; `last_update_date` = conversion. Attribution preserved (gforce4n6; @AlexisBrignoni).