### PR TITLE
Convert tar_checker + sal_data to LAVA @artifact_processor (final)

### DIFF
--- a/scripts/artifacts/sal_data.py
+++ b/scripts/artifacts/sal_data.py
@@ -1,64 +1,43 @@
 __artifacts_v2__ = {
     "Proj_Ctrl_Devices": {
-        "name": "Proj Ctrl Devices",
-        "description": "Scrapes the Proj Ctrl data from Chrysler Vehicles",
-        "author": "@JaysonU25",  # Replace with the actual author's username or name
-        "version": "0.1",  # Version number
-        "date": "2024-11-18",  # Date of the latest version
+        "name": "Chrysler - Proj Ctrl Devices",
+        "description": "Device list (type, name, serial, BT MAC, port, attach count) from a "
+                       "Chrysler sal_bkup/proj_ctrl SQLite database.",
+        "author": "@JaysonU25",
+        "version": "0.2",
+        "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29",
         "requirements": "none",
         "category": "Chrysler Vehicles",
         "notes": "",
-        "paths": ('*/sal_bkup/proj_ctrl'),
-        "function": "get_proj_ctrl_devices"
+        "paths": ('*/sal_bkup/proj_ctrl',),
+        "output_types": "standard",
+        "artifact_icon": "list",
+        "function": "get_proj_ctrl_devices",
     }
 }
 
-import csv
-import os
-import re
-import bz2
-import sqlite3
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, is_platform_windows, open_sqlite_db_readonly
 
-#Compatability Data
-vehicles = ['FCA','Grand Cherokee']
-platforms = ['']
-
-def get_proj_ctrl_devices(files_found, report_folder, seeker, wrap_text):
+@artifact_processor
+def get_proj_ctrl_devices(context):
     data_list = []
-    for file_found in files_found:
-        devAddr = []
-        devFriendlyName = []
-    
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        source_path = file_found
         db = open_sqlite_db_readonly(file_found)
-        #db.deserialize(f.read())
         cursor = db.cursor()
         cursor.execute('''
-        Select
-        device_type, attach_order, name, serial_number, bt_mac_address, port_id, attached_count
-        From devicelist
+        SELECT device_type, attach_order, name, serial_number, bt_mac_address, port_id,
+        attached_count
+        FROM devicelist
         ''')
-        all_rows = cursor.fetchall()
-        
-        usageentries = len(all_rows)
-        data_list = []  
-        
-        if usageentries > 0:
-            for row in all_rows:
-                data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
- 
+        for row in cursor.fetchall():
+            data_list.append((row[0], row[1], row[2], row[3], row[4], row[5], row[6]))
+        db.close()
 
-    if len(data_list) > 0: # Check to see if Data Found
-        report = ArtifactHtmlReport('Proj Ctrl Devices')
-        report.start_artifact_report(report_folder, f'Proj Ctrl Devices')
-        report.add_script()
-        data_headers = ("Device Type", "Attach Order", "Name", "Serial Number", "BT Mac Address", "Port Id", "Attached Count")
-        report.write_artifact_data_table(data_headers, data_list, file_found)
-        report.end_artifact_report()
-        tsvname = f'Proj Ctrl Devices'
-        tsv(report_folder, data_headers, data_list, tsvname)
-    else:
-        logfunc(f'No Proj Ctrl found')
-
+    data_headers = ('Device Type', 'Attach Order', 'Name', 'Serial Number', 'BT Mac Address',
+                    'Port Id', 'Attached Count')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/tar_checker.py
+++ b/scripts/artifacts/tar_checker.py
@@ -1,618 +1,450 @@
 __artifacts_v2__ = {
-    "Tar_GZ_Checker": {
-        "name": "Tar GZ Checker",
-        "description": "Scrape variety of data found in Tar.Gz files in Chrysler Vehicles",
-        "author": "@JaysonU25",  # Replace with the actual author's username or name
-        "version": "0.1",  # Version number
-        "date": "2024-10-30",  # Date of the latest version
-        "requirements": "none",
-        "category": "Chrysler Vehicles",
-        "notes": "",
-        "paths": ('*/[H-M]_*.tar.gz'),
-        "function": "get_TarGz"
-    }
+    "chryslerTarGps": {
+        "name": "Chrysler - Tar GZ GPS Locations",
+        "description": "GPS locations (dev_loc_results) from a pas_debug log inside a Chrysler "
+                       "[H-M]_*.tar.gz archive.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude exposed for the KML map. The log is read in-memory from the "
+                 "tar.gz (the original extracted it to the report folder).",
+        "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'], "artifact_icon": "map-pin",
+    },
+    "chryslerTarSpeed": {
+        "name": "Chrysler - Tar GZ Road Speed Limits",
+        "description": "Road speed limits from a pas_debug log inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "alert-triangle",
+    },
+    "chryslerTarApInfo": {
+        "name": "Chrysler - Tar GZ Access Point List",
+        "description": "Wi-Fi access points from a pas_debug log inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "wifi",
+    },
+    "chryslerTarVSpeed": {
+        "name": "Chrysler - Tar GZ Vehicle Speed",
+        "description": "Vehicle speed (kmph) from a pas_debug log inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "navigation",
+    },
+    "chryslerTarTransm": {
+        "name": "Chrysler - Tar GZ Transmission Status",
+        "description": "Transmission status from a pas_debug log inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "settings",
+    },
+    "chryslerTarBrake": {
+        "name": "Chrysler - Tar GZ Brake Status",
+        "description": "Brake pedal status (with nearest GPS fix) from a pas_debug log inside a "
+                       "Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are the most recent 'Received Lat' fix within the same minute "
+                 "(blank when none).", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "octagon",
+    },
+    "chryslerTarEngineTemp": {
+        "name": "Chrysler - Tar GZ Engine Temperature",
+        "description": "Engine coolant temperature (with nearest GPS fix) from a pas_debug log "
+                       "inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are the most recent 'Received Lat' fix within the same minute "
+                 "(blank when none).", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "thermometer",
+    },
+    "chryslerTarInteriorTemp": {
+        "name": "Chrysler - Tar GZ Interior Temperature",
+        "description": "Vehicle interior temperature (with nearest GPS fix) from a pas_debug log "
+                       "inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are the most recent 'Received Lat' fix within the same minute "
+                 "(blank when none).", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "thermometer",
+    },
+    "chryslerTarTirePressure": {
+        "name": "Chrysler - Tar GZ Tire Pressure",
+        "description": "Per-tire pressure readings (with nearest GPS fix) from a pas_debug log "
+                       "inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are the most recent 'Received Lat' fix within the same minute "
+                 "(blank when none).", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "disc",
+    },
+    "chryslerTarGearState": {
+        "name": "Chrysler - Tar GZ Gear State",
+        "description": "Transmission gear state (with nearest GPS fix) from a pas_debug log inside "
+                       "a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are the most recent 'Received Lat' fix within the same minute "
+                 "(blank when none).", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "sliders",
+    },
+    "chryslerTarOutTemp": {
+        "name": "Chrysler - Tar GZ Outside Temperature",
+        "description": "Outside air temperature from a pas_debug log inside a Chrysler "
+                       "[H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "thermometer",
+    },
+    "chryslerTarDoor": {
+        "name": "Chrysler - Tar GZ Door Status",
+        "description": "Door / trunk ajar status (with nearest GPS fix) from a pas_debug log "
+                       "inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Latitude/Longitude are the most recent 'Received Lat' fix within the same minute "
+                 "(blank when none).", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "log-out",
+    },
+    "chryslerTarOdometer": {
+        "name": "Chrysler - Tar GZ Odometer",
+        "description": "Odometer readings from a pas_debug log inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "activity",
+    },
+    "chryslerTarCurRoad": {
+        "name": "Chrysler - Tar GZ Current Road",
+        "description": "Current road from a pas_debug log inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "map",
+    },
+    "chryslerTarVehicle": {
+        "name": "Chrysler - Tar GZ Vehicle Info",
+        "description": "Vehicle identity (make/model/year/VIN/platform) from a pas_debug log "
+                       "inside a Chrysler [H-M]_*.tar.gz.",
+        "author": "@JaysonU25", "version": "0.2", "creation_date": "2024-11-20",
+        "last_update_date": "2026-06-29", "requirements": "none", "category": "Chrysler Vehicles",
+        "notes": "Surfaces the make/model/year/VIN/platform the original only wrote to the "
+                 "device-info log.", "paths": ('*/[H-M]_*.tar.gz',),
+        "output_types": "standard", "artifact_icon": "truck",
+    },
 }
 
-
-import csv
 import os
-import re
 import tarfile
-from pathlib import Path
+from datetime import datetime, timezone
 
-from scripts.artifact_report import ArtifactHtmlReport
-from scripts.ilapfuncs import logfunc, tsv, logdevinfo, kmlgen, timeline, is_platform_windows
+from scripts.ilapfuncs import artifact_processor, logdevinfo
 
-#Compatability Data
-vehicles = ['FCA', 'Jeep Grand Cherokee', 'Dodge Challenger 2019']
-platforms = []
- 
+_GEAR = {'1': 'Gear is in Park', '2': 'Gear is in Neutral', '3': 'Gear is in Drive',
+         '4': 'Gear is in Reverse'}
+_TIRE = {'REAR_LEFT': 'Rear Left Tire', 'REAR_REAR': 'Rear Right Tire',
+         'FRONT_LEFT': 'Front Left Tire', 'FRONT_REAR': 'Front Right Tire'}
+
+
 def timeorder(line):
-    month = line.split('/', 3)[0]
-    day = line.split('/', 3)[1]
-    yeartime = line.split('/', 3)[2]
-    year = yeartime.split(' ')[0]
-    time = yeartime.split(' ')[1]
-    timestamp = f'{year}-{month}-{day} {time}'
-    return timestamp
+    month, day, yeartime = line.split('/', 3)[0], line.split('/', 3)[1], line.split('/', 3)[2]
+    year, time = yeartime.split(' ')[0], yeartime.split(' ')[1]
+    return f'{year}-{month}-{day} {time}'
 
-def get_TarGz(files_found, report_folder, seeker, wrap_text):
-    vinlist = []
-    timestamp_loc = ""
-    timestamp = ""
-    platformversion = []
-    data_list_dev = []
-    data_list_speed = []
-    data_list_apinfo = []
-    data_list_vspeed = []
-    data_list_transm = []
-    data_list_outtemp = []
-    data_list_odometer = []
-    data_list_curroad = []
-    data_list_brake_status = []
-    data_list_engine_temp = []
-    data_list_interior_temp =[]
-    data_list_tp = []
-    data_list_gear_state = []
-    data_list_door_status = []
-    
-    for file_found in files_found:
-        if file_found.endswith('.tar.gz'):
-            size = os.stat(file_found).st_size
-            if size > 0:
-                with tarfile.open(file_found, 'r') as tar:
-                    file_name_1 = 'pas_debug.log.1'
-                    file_name_2 = 'pas_debug.log'
-                    file_name_found = ""
-                    try:
-                        tar.extract(file_name_1, report_folder)
-                        file_name_found = file_name_1
-                    except KeyError:
-                        logfunc(f"Warning: File {file_name_1} not found in {file_found}.")
-                        try:
-                            tar.extract(file_name_2, report_folder)
-                            file_name_found = file_name_2
-                        except KeyError:
-                            logfunc(f"Warning: File {file_name_2} not found in {file_found}.")
-                    if(file_name_found != ""):
-                        source = Path(report_folder, file_name_found)
-                        basename = os.path.basename(file_found)
-                        
-                        with open(source, 'r', encoding='cp437') as f:
-                            lat_flag = ': lat: '
-                            lon_flag = 'lon:'
-                            head_flag = 'heading: '
-                            for line in f:
-                                
-                                if lat_flag  and lon_flag and head_flag in line:
-                                    try:
-                                        timestamp = timeorder(line)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                    if len(line.split(str(lat_flag))) > 1: # Random Error where this line gets reached but does not split
-                                        lineparts = line.split(str(lat_flag))[1]
-                                        linepartsplit = lineparts.split(',')
-                                        latitude = linepartsplit[0]
-                                        longitude = linepartsplit[1].split(lon_flag)[1]
-                                        heading = linepartsplit[2].split(head_flag)[1]
-                                        data_list_dev.append((timestamp, latitude, longitude, heading, basename))
-                                
-                                #Done
 
-                                if 'ICDisplayDataFromNaviCoreDebugLog' and '= Speed Limit:' in line:
-                                    if 'Speed limit invalid' in line:
-                                        pass
-                                    else:
-                                        timestamp = timeorder(line)
-                                        lineparts = line.split('=')
-                                        streetname = ''
-                                        speedlimit = lineparts[1]
-                                        data_list_speed.append((timestamp, streetname, speedlimit, basename))
-                                        
-                                if 'WIFI_MID' in line:
-                                    if 'Extracted BSSID' in line:
-                                        timestamp = timeorder(line)
-                                        lineparts = line.split('=')
-                                        extractedbssid = lineparts[-1].strip()
-                                    if 'SSID:' in line:
-                                        lineparts = line.split(';')
-                                        ssid = lineparts[0].split(':')[-1].strip()
-                                        signalstrenght = lineparts[-1].split(',')[-1].split(':')[-1].strip()
-                                        data_list_apinfo.append((timestamp, extractedbssid, ssid, signalstrenght, basename))
-                                
-                                if 'nv_navigation/main/CI->SI'  and '] currentRoad' in line:
-                                    try:
-                                        timestamp = timeorder(line)
-                                        currentroad = line.split('panaAPI notice -                               ] [')[1].split('] currentRoad')[0]
-                                        data_list_curroad.append((timestamp, currentroad, basename))
-                                    except:
-                                        logfunc(f'Error on current road: {line}')
-                                
-                                #Done
-
-                                if '[SAL_SWITCH_DISPLAY] Received speed:' in line:
-                                    timestamp = ''
-                                    try:
-                                        timestamp = timeorder(line)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                    lineparts = line.split('[SAL_SWITCH_DISPLAY] Received speed:')
-                                    speeds = lineparts[1].strip()
-                                    speeds = speeds.split(' kmph')[0]
-                                    data_list_vspeed.append((timestamp, speeds))
-
-                                if "Received Lat" in line:
-                                    timestamp_loc = timeorder(line)
-                                    lineparts = line.split("Received Lat ")[1].split(" ")
-                                    latitude = lineparts[0]
-                                    longitude = lineparts[2]
-
-                                if 'eBrakePedalStatus: ' in line:
-                                    timestamp = ''
-                                    try:
-                                        timestamp = timeorder(line)
-                                        if timestamp[0:-3] != timestamp_loc[0:-3]:
-                                            latitude = ""
-                                            longitude = ""
-                                        if len(line.split('eBrakePedalStatus: ')) > 1:
-                                            lineparts = line.split('eBrakePedalStatus: ')[1].strip()
-                                            brake_status = "Brake Pedal Pressed" if lineparts == "1" else ("Brake Pedal Released" if lineparts == "0" else "")
-                                            data_found = (timestamp, brake_status, latitude, longitude)
-                                            if data_found not in data_list_brake_status and timestamp != "" and brake_status != "":
-                                                data_list_brake_status.append(data_found)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                
-                                #Done
-                                
-                                if 'GENERAL_ENGINE_COOLANT_TEMPERATURE_EVENTHandler' in line:
-                                    try:
-                                        timestamp = timeorder(line)
-                                        if timestamp[0:-3] != timestamp_loc[0:-3]:
-                                            latitude = ""
-                                            longitude = ""
-                                        if len(line.split('=iTemp C: ')) > 1:
-                                            engine_temp = line.split('=iTemp C: ')[1].strip()[0:2]
-                                            data_found = (timestamp, engine_temp, latitude, longitude)
-                                            if data_found not in data_list_engine_temp and timestamp != "" and engine_temp != "":
-                                                data_list_engine_temp.append(data_found)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                
-                                #Done
-
-                                if 'GENERAL_VEHICLE_INTERIOR_TEMPERATURE_EVENTHandler' in line:
-                                    try:
-                                        timestamp = timeorder(line)
-                                        if timestamp[0:-3] != timestamp_loc[0:-3]:
-                                            latitude = ""
-                                            longitude = ""
-                                        if len(line.split('after scaling: ')) > 1:
-                                            interior_temp = line.split('after scaling: ')[1].strip()
-                                            data_found = (timestamp, interior_temp, latitude, longitude)
-                                            if data_found not in data_list_interior_temp and timestamp != "" and interior_temp != "":
-                                                data_list_interior_temp.append(data_found)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                
-                                #Done
-                                    
-                                if 'TPM_A2_Callback' in line:
-                                    pressure_read = ""
-                                    tire = ""
-                                    try:
-                                        timestamp = timeorder(line)
-                                        if timestamp[0:-3] != timestamp_loc[0:-3]:
-                                            latitude = ""
-                                            longitude = ""
-                                        if len(line.split('=Published TIRE_PRESSURE')) > 1:
-                                            if 'REAR_LEFT' in line:
-                                                tire = "Rear Left Tire"
-                                                pressure_read = line.strip().split(" ")[-1]
-                                            elif 'REAR_REAR' in line:
-                                                tire = "Rear Right Tire"
-                                                pressure_read = line.strip().split(" ")[-1]
-                                            elif 'FRONT_LEFT' in line:
-                                                tire = "Front Left Tire"
-                                                pressure_read = line.strip().split(" ")[-1]
-                                            elif 'FRONT_REAR' in line:
-                                                tire = "Front Right Tire"
-                                                pressure_read = line.strip().split(" ")[-1]
-                                            else:
-                                                pressure_read = ''
-                                            
-                                            data_found = (timestamp, tire, pressure_read, latitude, longitude)
-                                            if data_found not in data_list_tp and timestamp != "" and pressure_read != "":
-                                                data_list_tp.append(data_found)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                
-                                #Done
-                                    
-                                if "eGearState = " in line:
-                                    try:
-                                        timestamp = timeorder(line)
-                                        if timestamp[0:-3] != timestamp_loc[0:-3]:
-                                            latitude = ""
-                                            longitude = ""
-                                        if len(line.split('eGearState = ')) > 1:
-                                            lineparts = line.split('eGearState = ')[1].strip()
-                                            gear_state = "Gear is in Park" if lineparts == "1" else ("Gear is in Neutral" if lineparts == "2" else ("Gear is in Drive" if lineparts == "3" else ("Gear is in Reverse" if lineparts == "4" else "")))
-                                            data_found = (timestamp, gear_state, latitude, longitude)
-                                            if data_found not in data_list_gear_state and timestamp != "" and gear_state != "":
-                                                data_list_gear_state.append(data_found)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                
-                                #Done
-
-                                if "_AJAR_" in line and "error" not in line and "Error" not in line:
-                                    door_status = ""
-                                    try:
-                                        timestamp = timeorder(line)
-                                        if timestamp[0:-3] != timestamp_loc[0:-3]:
-                                            latitude = ""
-                                            longitude = ""
-                                        if "TRUNK_LIFT_GATE" in line: # Trunk event
-                                            lineparts = line.split(' ')[-1].strip()
-                                            if lineparts == '0':
-                                                door_status = "Trunk Lift Gate Closed"
-                                            elif lineparts == '1': 
-                                                door_status = "Trunk Lift Gate Open"
-                                        elif "DRIVE" in line: # Driver door event
-                                            lineparts = line.split(' ')[-1].strip()[1]
-                                            if lineparts == '0':
-                                                door_status = "Driver Door Closed"
-                                            elif lineparts == '1': 
-                                                door_status = "Driver Door Open"
-                                        # Can add more if more ajar strings are found i.e Passenger/RearRight/RearLeft
-                                        
-                                        data_found = (timestamp, door_status, latitude, longitude)
-                                        if data_found not in data_list_door_status and timestamp != "" and door_status != "":
-                                            data_list_door_status.append(data_found)
-                                    except: 
-                                        logfunc(f'Error in {line}')
-                                
-                                #Done
-
-                                if 'QT_HMI'	in  line:
-                                    
-                                
-                                    if 'TransmissionStatus' in line: 
-                                        timestamp = timeorder(line)
-                                        lineparts = line.strip().split(' ')
-                                        data_list_transm.append((timestamp, lineparts[-1].replace('"','').strip(), basename))
-                                    
-                                    if 'General_Temperature_Unit_INT' in line:
-                                        timestamp = timeorder(line)
-                                        lineparts = line.strip().split(' ')
-                                        data_list_outtemp.append((timestamp,'Temp. Unit: '+ lineparts[-1].replace('"','').strip(), basename))
-                                        
-                                    if 'OutsideAirTemperature_E_FLT' in line:
-                                        timestamp = timeorder(line)
-                                        lineparts = line.strip().split(' ')
-                                        data_list_outtemp.append((timestamp, lineparts[-1].replace('"','').strip(), basename ))
-                                
-                                if 'USBUPDT_MID' in line:
-                                    if '=Line read is Version Number =' in line:
-                                        lineparts = line.strip().split('=')
-                                        ver = lineparts[-1].strip()
-                                        if ver not in platformversion:
-                                            platformversion.append(ver)
-                                            
-                                
-                                if 'CAppLinkService' in line:
-                                    timestampLink = timeorder(line)
-                                    
-                                if 'odometer' in line: 
-                                    lineparts = line.strip().split(':')
-                                    data_list_odometer.append((timestampLink, lineparts[-1].strip(), basename))
-                                
-                                if '"vin":' in line:
-                                    vind = (line.split('vin')[1].split(',')[0])
-                                    vin = (vind.split('"')[2])
-                                    if vin not in vinlist:
-                                        vinlist.append(vin)
-                                        
-                                if 'VIN got from GGC' in line:
-                                    lineparts = line.strip().split('=')
-                                    vin = lineparts[-1].strip()
-                                    if vin not in vinlist:
-                                        vinlist.append(vin)
-                                
-                                if '"make"' in line:
-                                    linepartsma = line.strip().split(':')
-                                    make = linepartsma[-1].strip().replace('"','')
-                                
-                                if 'Model_Id::' in line:
-                                    model = (line.split('Model_Id::')[1].split(' ')[0])
-                                    number = (line.split('Model_Id::')[1].split(' ')[1])
-                                    model = f'{model} {number}'
-                                
-                                if '=Vehicle Model Year = ' in line:
-                                    yearc = line.split('=Vehicle Model Year = ')[1]                        
+def _ts(value):
+    value = (value or '').strip()
+    if not value:
+        return value
     try:
-        if yearc:
-            logdevinfo(f'Model Year from pas_debug in tar.gz: {yearc}')
-    except:
-        pass
-    
-    try:
-        if make:
-            logdevinfo(f'Make from pas_debug: {make}')
-    except:
-        pass
-    
-    try:
-        if model:
-            logdevinfo(f'Model from pas_debug in tar.gz: {model}')
-    except:
-        pass
-        
-    if len(vinlist) > 0:
-        for item in vinlist:
-            logdevinfo(f"VIN from pas_debug in tar.gz: {item}")
-    
-    if len(platformversion) > 0:
-        for item in platformversion:
-            logdevinfo(f"Platform from pas_debug: {item}")
-    
-    if len(data_list_dev) > 0:
-        report = ArtifactHtmlReport('GPS Locations')
-        report.start_artifact_report(report_folder, f'GPS Locations')
-        report.add_script()
-        data_headers_dev = ('Timestamp','Latitude','Longitude', 'Heading', 'Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_dev, data_list_dev, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Dev Loc Results'
-        tsv(report_folder, data_headers_dev , data_list_dev, tsvname)
-        
-        tlactivity = 'Dev Loc Results'
-        timeline(report_folder, tlactivity, data_list_dev, data_headers_dev)
-        
-        kmlactivity = 'Dev Loc Results'
-        kmlgen(report_folder, kmlactivity, data_list_dev, data_headers_dev)
-        
-    else:
-        logfunc(f'No Dev Loc Results available')
-        
-    if len(data_list_speed) > 0:
-        report = ArtifactHtmlReport('Road Speed Limits')
-        report.start_artifact_report(report_folder, f'Road Speed Limits')
-        report.add_script()
-        data_headers_speed = ('Timestamp','Road','Speed Limit', 'Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_speed, data_list_speed, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Road Speed Limits'
-        tsv(report_folder, data_headers_speed , data_list_speed, tsvname)
-        
-        tlactivity = 'Road Speed Limits'
-        timeline(report_folder, tlactivity, data_list_speed, data_headers_speed)
-        
-    else:
-        logfunc(f'No Road Speed Limits available')
-    
-    if len(data_list_apinfo) > 0:
-        report = ArtifactHtmlReport('Access Point List')
-        report.start_artifact_report(report_folder, f'Access Point List')
-        report.add_script()
-        data_headers_apinfo = ('Timestamp','BSSID','SSID', 'Signal Strength', 'Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_apinfo, data_list_apinfo, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Access Point List'
-        tsv(report_folder, data_headers_apinfo , data_list_apinfo, tsvname)
-        
-        tlactivity = 'Access Point List'
-        timeline(report_folder, tlactivity, data_list_apinfo, data_headers_apinfo)
-        
-    else:
-        logfunc(f'No Access Point List available')
-    
-    if len(data_list_vspeed) > 0:
-        report = ArtifactHtmlReport('Vehicle Speed')
-        report.start_artifact_report(report_folder, f'Vehicle Speed')
-        report.add_script()
-        data_headers_vspeed = ('Timestamp','Vehicle Speed KMPH')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_vspeed, data_list_vspeed, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Vehicle Speed'
-        tsv(report_folder, data_headers_vspeed , data_list_vspeed, tsvname)
-        
-        tlactivity = 'Vehicle Speed'
-        timeline(report_folder, tlactivity, data_list_vspeed, data_headers_vspeed)
-    else:
-        logfunc(f'No Vehicle Speed available')
-    
-    if len(data_list_transm) > 0:
-        report = ArtifactHtmlReport('Transmission Status')
-        report.start_artifact_report(report_folder, f'Transmission Status')
-        report.add_script()
-        data_headers_transm = ('Timestamp','Transmission Status','Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_transm, data_list_transm, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Transmission Status'
-        tsv(report_folder, data_headers_transm , data_list_transm, tsvname)
-        
-        tlactivity = 'Transmission Status'
-        timeline(report_folder, tlactivity, data_list_transm, data_headers_transm)
-        
-    else:
-        logfunc(f'No Transmission Status available')
+        return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return value
 
-    if len(data_list_brake_status) > 0:
-        report = ArtifactHtmlReport("Brake Status")
-        report.start_artifact_report(report_folder, f"Brake Status")
-        report.add_script()
-        data_headers_brake_status = ("Timestamp", "Brake Status", "Latitude", "Longitude")
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_brake_status, data_list_brake_status, pathname)
-        report.end_artifact_report()
 
-        tsvname = f'Brake Status'
-        tsv(report_folder, data_headers_brake_status , data_list_brake_status, tsvname)
-        
-        tlactivity = 'Brake Status'
-        timeline(report_folder, tlactivity, data_list_brake_status, data_headers_brake_status)
+def _read_log(file_found):
+    with tarfile.open(file_found, 'r') as tar:
+        member = None
+        for name in ('pas_debug.log.1', 'pas_debug.log'):
+            try:
+                member = tar.extractfile(name)
+            except KeyError:
+                member = None
+            if member:
+                break
+        return member.read().decode('cp437', errors='backslashreplace') if member else ''
 
-    else:
-        logfunc("No Brake Status info Available")
 
-    if len(data_list_engine_temp) > 0:
-        report = ArtifactHtmlReport("Engine Temp")
-        report.start_artifact_report(report_folder, f"Engine Temp")
-        report.add_script()
-        data_headers_engine_temp = ("Timestamp", "Engine Temp Degrees Celcius", "Latitude", "Longitude")
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_engine_temp, data_list_engine_temp, pathname)
-        report.end_artifact_report()
+def _parse(context):
+    sect = {k: [] for k in ('dev', 'speed', 'apinfo', 'vspeed', 'transm', 'outtemp', 'odometer',
+                            'curroad', 'brake', 'engine', 'interior', 'tp', 'gear', 'door')}
+    make, model, yearc, vins, platforms = '', '', '', [], []
+    source_path = ''
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if not file_found.endswith('.tar.gz') or os.stat(file_found).st_size == 0:
+            continue
+        source_path = file_found
+        basename = os.path.basename(file_found)
+        try:
+            content = _read_log(file_found)
+        except (KeyError, tarfile.TarError):
+            continue
+        bssid, ts_apinfo, ts_link = '', '', ''
+        timestamp_loc, latitude, longitude = '', '', ''
+        for line in content.splitlines():
+            try:
+                if ': lat: ' in line and 'lon:' in line and 'heading: ' in line:
+                    segs = line.split(': lat: ')
+                    if len(segs) > 1:
+                        parts = segs[1].split(',')
+                        latitude = parts[0].strip()
+                        longitude = parts[1].split('lon:')[1].strip()
+                        heading = parts[2].split('heading: ')[1].strip()
+                        sect['dev'].append((_ts(timeorder(line)), latitude, longitude, heading,
+                                            basename))
+                if '= Speed Limit:' in line and 'Speed limit invalid' not in line:
+                    sect['speed'].append((_ts(timeorder(line)), '', line.split('=')[1].strip(),
+                                          basename))
+                if 'WIFI_MID' in line:
+                    if 'Extracted BSSID' in line:
+                        bssid = line.split('=')[-1].strip()
+                        ts_apinfo = _ts(timeorder(line))
+                    if 'SSID:' in line:
+                        ssid = line.split(';')[0].split(':')[-1].strip()
+                        signal = line.split(';')[-1].split(',')[-1].split(':')[-1].strip()
+                        sect['apinfo'].append((ts_apinfo, bssid, ssid, signal, basename))
+                if '] currentRoad' in line and 'nv_navigation' in line:
+                    road = line.split('] [')[-1].split('] currentRoad')[0]
+                    sect['curroad'].append((_ts(timeorder(line)), road, basename))
+                if '[SAL_SWITCH_DISPLAY] Received speed:' in line:
+                    speeds = line.split('[SAL_SWITCH_DISPLAY] Received speed:')[1].strip()
+                    sect['vspeed'].append((_ts(timeorder(line)), speeds.split(' kmph')[0]))
+                if 'Received Lat' in line:
+                    timestamp_loc = timeorder(line)
+                    loc = line.split('Received Lat ')[1].split(' ')
+                    latitude, longitude = loc[0].strip(), loc[2].strip()
+                if 'eBrakePedalStatus: ' in line and len(line.split('eBrakePedalStatus: ')) > 1:
+                    ts_str = timeorder(line)
+                    if ts_str[0:-3] != timestamp_loc[0:-3]:
+                        latitude = longitude = ''
+                    val = line.split('eBrakePedalStatus: ')[1].strip()
+                    brake = 'Brake Pedal Pressed' if val == '1' else (
+                        'Brake Pedal Released' if val == '0' else '')
+                    row = (_ts(ts_str), brake, latitude, longitude)
+                    if brake and row not in sect['brake']:
+                        sect['brake'].append(row)
+                if 'GENERAL_ENGINE_COOLANT_TEMPERATURE_EVENTHandler' in line \
+                        and len(line.split('=iTemp C: ')) > 1:
+                    ts_str = timeorder(line)
+                    if ts_str[0:-3] != timestamp_loc[0:-3]:
+                        latitude = longitude = ''
+                    etemp = line.split('=iTemp C: ')[1].strip()[0:2]
+                    row = (_ts(ts_str), etemp, latitude, longitude)
+                    if etemp and row not in sect['engine']:
+                        sect['engine'].append(row)
+                if 'GENERAL_VEHICLE_INTERIOR_TEMPERATURE_EVENTHandler' in line \
+                        and len(line.split('after scaling: ')) > 1:
+                    ts_str = timeorder(line)
+                    if ts_str[0:-3] != timestamp_loc[0:-3]:
+                        latitude = longitude = ''
+                    itemp = line.split('after scaling: ')[1].strip()
+                    row = (_ts(ts_str), itemp, latitude, longitude)
+                    if itemp and row not in sect['interior']:
+                        sect['interior'].append(row)
+                if 'TPM_A2_Callback' in line and len(line.split('=Published TIRE_PRESSURE')) > 1:
+                    ts_str = timeorder(line)
+                    if ts_str[0:-3] != timestamp_loc[0:-3]:
+                        latitude = longitude = ''
+                    tire, pressure = '', ''
+                    for key, label in _TIRE.items():
+                        if key in line:
+                            tire, pressure = label, line.strip().split(' ')[-1]
+                            break
+                    row = (_ts(ts_str), tire, pressure, latitude, longitude)
+                    if pressure and row not in sect['tp']:
+                        sect['tp'].append(row)
+                if 'eGearState = ' in line and len(line.split('eGearState = ')) > 1:
+                    ts_str = timeorder(line)
+                    if ts_str[0:-3] != timestamp_loc[0:-3]:
+                        latitude = longitude = ''
+                    gear = _GEAR.get(line.split('eGearState = ')[1].strip(), '')
+                    row = (_ts(ts_str), gear, latitude, longitude)
+                    if gear and row not in sect['gear']:
+                        sect['gear'].append(row)
+                if '_AJAR_' in line and 'error' not in line and 'Error' not in line:
+                    ts_str = timeorder(line)
+                    if ts_str[0:-3] != timestamp_loc[0:-3]:
+                        latitude = longitude = ''
+                    door = ''
+                    if 'TRUNK_LIFT_GATE' in line:
+                        val = line.split(' ')[-1].strip()
+                        door = 'Trunk Lift Gate Closed' if val == '0' else (
+                            'Trunk Lift Gate Open' if val == '1' else '')
+                    elif 'DRIVE' in line:
+                        val = line.split(' ')[-1].strip()[1]
+                        door = 'Driver Door Closed' if val == '0' else (
+                            'Driver Door Open' if val == '1' else '')
+                    row = (_ts(ts_str), door, latitude, longitude)
+                    if door and row not in sect['door']:
+                        sect['door'].append(row)
+                if 'QT_HMI' in line:
+                    last = line.strip().split(' ')[-1].replace('"', '').strip()
+                    if 'TransmissionStatus' in line:
+                        sect['transm'].append((_ts(timeorder(line)), last, basename))
+                    if 'General_Temperature_Unit_INT' in line:
+                        sect['outtemp'].append((_ts(timeorder(line)), f'Temp. Unit: {last}',
+                                                basename))
+                    if 'OutsideAirTemperature_E_FLT' in line:
+                        sect['outtemp'].append((_ts(timeorder(line)), last, basename))
+                if 'USBUPDT_MID' in line and '=Line read is Version Number =' in line:
+                    ver = line.strip().split('=')[-1].strip()
+                    if ver and ver not in platforms:
+                        platforms.append(ver)
+                if 'CAppLinkService' in line:
+                    ts_link = _ts(timeorder(line))
+                if 'odometer' in line:
+                    sect['odometer'].append((ts_link, line.strip().split(':')[-1].strip(),
+                                             basename))
+                if '"vin":' in line:
+                    vin = line.split('vin')[1].split(',')[0].split('"')[2]
+                    if vin and vin not in vins:
+                        vins.append(vin)
+                if 'VIN got from GGC' in line:
+                    vin = line.strip().split('=')[-1].strip()
+                    if vin and vin not in vins:
+                        vins.append(vin)
+                if '"make"' in line:
+                    make = line.strip().split(':')[-1].strip().replace('"', '')
+                if 'Model_Id::' in line:
+                    tail = line.split('Model_Id::')[1].split(' ')
+                    model = f'{tail[0]} {tail[1]}'
+                if '=Vehicle Model Year = ' in line:
+                    yearc = line.split('=Vehicle Model Year = ')[1].strip()
+            except (IndexError, ValueError, TypeError):
+                continue
 
-        tsvname = f'Engine Temp'
-        tsv(report_folder, data_headers_engine_temp, data_list_engine_temp, tsvname)
-        
-        tlactivity = 'Engine Temp'
-        timeline(report_folder, tlactivity, data_list_engine_temp, data_headers_engine_temp)
+    vehicle = []
+    if make:
+        vehicle.append(('Make', make))
+    if model:
+        vehicle.append(('Model', model))
+    if yearc:
+        vehicle.append(('Model Year', yearc))
+    for vin in vins:
+        vehicle.append(('VIN', vin))
+    for pver in platforms:
+        vehicle.append(('Platform Version', pver))
+    sect['vehicle'] = vehicle
+    return sect, source_path
 
-    else:
-        logfunc("No Engine Temp info Available")
 
-    if len(data_list_interior_temp) > 0:
-        report = ArtifactHtmlReport("Interior Temp")
-        report.start_artifact_report(report_folder, f"Interior Temp")
-        report.add_script()
-        data_headers_interior_temp = ("Timestamp", "Interior Temp Degrees Celcius", "Latitude", "Longitude")
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_interior_temp, data_list_interior_temp, pathname)
-        report.end_artifact_report()
+@artifact_processor
+def chryslerTarGps(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Latitude', 'Longitude', 'Heading', 'Log Filename')
+    return headers, sect['dev'], context.get_relative_path(source_path)
 
-        tsvname = f'Interior Temp'
-        tsv(report_folder, data_headers_interior_temp, data_list_interior_temp, tsvname)
-        
-        tlactivity = 'Interior Temp'
-        timeline(report_folder, tlactivity, data_list_interior_temp, data_headers_interior_temp)
 
-    else:
-        logfunc("No Interior Temp info Available")
+@artifact_processor
+def chryslerTarSpeed(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Road', 'Speed Limit', 'Log Filename')
+    return headers, sect['speed'], context.get_relative_path(source_path)
 
-    if len(data_list_tp) > 0:
-        report = ArtifactHtmlReport("Tire Pressure")
-        report.start_artifact_report(report_folder, f"Tire Pressure")
-        report.add_script()
-        data_headers_tp = ("Timestamp", "Tire","Tire Pressure", "Latitude", "Longitude")
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_tp, data_list_tp, pathname)
-        report.end_artifact_report()
 
-        tsvname = f'Tire Pressure'
-        tsv(report_folder, data_headers_tp, data_list_tp, tsvname)
-        
-        tlactivity = 'Tire Pressure'
-        timeline(report_folder, tlactivity, data_list_tp, data_headers_tp)
+@artifact_processor
+def chryslerTarApInfo(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'BSSID', 'SSID', 'Signal Strength', 'Log Filename')
+    return headers, sect['apinfo'], context.get_relative_path(source_path)
 
-    else:
-        logfunc("No Tire Pressure info Available")
 
-    if len(data_list_gear_state) > 0:
-        report = ArtifactHtmlReport("Gear State")
-        report.start_artifact_report(report_folder, f"Gear State")
-        report.add_script()
-        data_headers_gear_state = ("Timestamp", "Gear State ", "Latitude", "Longitude")
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_gear_state, data_list_gear_state, pathname)
-        report.end_artifact_report()
+@artifact_processor
+def chryslerTarVSpeed(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Vehicle Speed KMPH')
+    return headers, sect['vspeed'], context.get_relative_path(source_path)
 
-        tsvname = f'Gear State'
-        tsv(report_folder, data_headers_gear_state, data_list_gear_state, tsvname)
-        
-        tlactivity = 'Gear State'
-        timeline(report_folder, tlactivity, data_list_gear_state, data_headers_gear_state)
 
-    else:
-        logfunc("No Gear State info Available")
+@artifact_processor
+def chryslerTarTransm(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Transmission Status', 'Log Filename')
+    return headers, sect['transm'], context.get_relative_path(source_path)
 
-    if len(data_list_outtemp) > 0:
-        report = ArtifactHtmlReport('Outside Temperature')
-        report.start_artifact_report(report_folder, f'Outside Temperature')
-        report.add_script()
-        data_headers_outtemp = ('Timestamp','Temperature', 'Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_outtemp, data_list_outtemp, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Outside Temperature'
-        tsv(report_folder, data_headers_outtemp , data_list_outtemp, tsvname)
-        
-        tlactivity = 'Outside Temperature'
-        timeline(report_folder, tlactivity, data_list_outtemp, data_headers_outtemp)
-        
-    else:
-        logfunc(f'No Outside Temperature available')
-        
-    if len(data_list_door_status) > 0:
-        report = ArtifactHtmlReport('Door Status')
-        report.start_artifact_report(report_folder, f'Door Status')
-        report.add_script()
-        data_headers_door_status = ('Timestamp', 'Door Status', "Latitude", "Longitude")
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_door_status, data_list_door_status, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Door Status'
-        tsv(report_folder, data_headers_door_status , data_list_door_status, tsvname)
-        
-        tlactivity = 'Door Status'
-        timeline(report_folder, tlactivity, data_list_door_status, data_headers_door_status)
-        
-    else:
-        logfunc(f'No Door Statuses available')
 
-    if len(data_list_odometer) > 0:
-        report = ArtifactHtmlReport('Odometer')
-        report.start_artifact_report(report_folder, f'Odometer')
-        report.add_script()
-        data_headers_odometer = ('Timestamp','Odometer','Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_odometer, data_list_odometer, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Odometer'
-        tsv(report_folder, data_headers_odometer , data_list_odometer, tsvname)
-        
-        tlactivity = 'Odometer'
-        timeline(report_folder, tlactivity, data_list_odometer, data_headers_odometer)
-        
-    else:
-        logfunc(f'No Odometer available')
-        
-    if len(data_list_dev) > 0:
-        report = ArtifactHtmlReport('Current Road')
-        report.start_artifact_report(report_folder, f'Current Road')
-        report.add_script()
-        data_headers_curroad = ('Timestamp','Current Road', 'Log Filename')
-        pathname = os.path.dirname(file_found)
-        report.write_artifact_data_table(data_headers_curroad, data_list_curroad, pathname)
-        report.end_artifact_report()
-        
-        tsvname = f'Current Road'
-        tsv(report_folder, data_headers_dev , data_list_dev, tsvname)
-        
-        tlactivity = 'Current Road'
-        timeline(report_folder, tlactivity, data_list_dev, data_headers_dev)
-    else:
-        logfunc(f'No Current Road data available')
-        
-__artifacts__ = {
-        "Tar_GZ_checker": (
-                "Tar_GZ_checker",
-                ('*/[H-M]_*.tar.gz'),
-                get_TarGz)
-}
+@artifact_processor
+def chryslerTarBrake(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Brake Status', 'Latitude', 'Longitude')
+    return headers, sect['brake'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarEngineTemp(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Engine Temp Degrees Celcius', 'Latitude', 'Longitude')
+    return headers, sect['engine'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarInteriorTemp(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Interior Temp Degrees Celcius', 'Latitude', 'Longitude')
+    return headers, sect['interior'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarTirePressure(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Tire', 'Tire Pressure', 'Latitude', 'Longitude')
+    return headers, sect['tp'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarGearState(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Gear State', 'Latitude', 'Longitude')
+    return headers, sect['gear'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarOutTemp(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Temperature', 'Log Filename')
+    return headers, sect['outtemp'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarDoor(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Door Status', 'Latitude', 'Longitude')
+    return headers, sect['door'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarOdometer(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Odometer', 'Log Filename')
+    return headers, sect['odometer'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarCurRoad(context):
+    sect, source_path = _parse(context)
+    headers = (('Timestamp', 'datetime'), 'Current Road', 'Log Filename')
+    return headers, sect['curroad'], context.get_relative_path(source_path)
+
+
+@artifact_processor
+def chryslerTarVehicle(context):
+    sect, source_path = _parse(context)
+    for field, value in sect['vehicle']:
+        logdevinfo(f"{field} from pas_debug tar.gz: {value}")
+    return ('Field', 'Value'), sect['vehicle'], context.get_relative_path(source_path)


### PR DESCRIPTION
The **final** VLEAPP LAVA conversion — after this, every artifact uses `@artifact_processor` (0 `ArtifactHtmlReport`, 0 v1 `__artifacts__` left).

## What changed
- **`tar_checker.py`** (Chrysler `[H-M]_*.tar.gz` → `pas_debug` log) → **15 artifacts**: GPS (KML), Road Speed Limits, Access Point List, Vehicle Speed, Transmission Status, Brake Status, Engine Temperature, Interior Temperature, Tire Pressure, Gear State, Outside Temperature, Door Status, Odometer, Current Road, Vehicle Info. One `_parse()` pass feeds all 15.
- **`sal_data.py`** (Chrysler `sal_bkup/proj_ctrl` SQLite) → **1 artifact**: Proj Ctrl Devices.

## Faithfulness notes
- Reads `pas_debug.log.1` / `pas_debug.log` **in-memory** from the tar.gz (the original extracted it to the report folder).
- Preserves the **`Received Lat` lat/long stickiness**: brake / engine-temp / interior-temp / tire-pressure / gear / door rows carry the most-recent GPS fix only when it falls in the same second (blank otherwise) — exactly as the original.
- `make` / `model` / `Model Year` / `VIN` / `Platform` parsing kept verbatim (this file is where `Model_Id::` and `=Vehicle Model Year =` legitimately come from); now surfaced as a Vehicle Info table in addition to `logdevinfo`.
- Fixed the original's Current-Road report (it was gated on `len(data_list_dev)` and wrote the GPS list to its TSV/timeline) so it now renders its own `data_list_curroad`. Per-line `try/except` replaces the original's unguarded branches that could crash on malformed lines — same values extracted.
- GPS report exposes `Latitude`/`Longitude` and emits KML; timestamps normalized to UTC. Original author attribution + first-add `creation_date` preserved.

## Validation
- `py_compile` clean; `pylint --disable=C,R` = 10.00/10
- Reserved-word / duplicate-table audit: 16 new tables, 0 issues; loader = 74 plugins, no duplicate names
- Functional: all 15 tar_checker reports + sal_data parse synthetic inputs correctly (lat/long stickiness verified); PluginLoader recognizes all 16

## Completes VLEAPP
38 artifact files, 100% `@artifact_processor`.