### PR TITLE
Fix runtime metadata loss on legacy function-key artifacts

### DIFF
--- a/scripts/artifacts/Ford_Model.py
+++ b/scripts/artifacts/Ford_Model.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Ford_Model": {
+    "get_Model": {
         "name": "Vehicle Model",
         "description": "Vehicle/head-unit model from a Ford bluetooth_v1.ddb.",
         "author": "@JaysonU25",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/bluetooth_v1.ddb',),
         "output_types": "standard",
         "artifact_icon": "truck",
-        "function": "get_Model",
     }
 }
 

--- a/scripts/artifacts/chrysler_devices.py
+++ b/scripts/artifacts/chrysler_devices.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Device_Manager_Devices": {
+    "get_devices": {
         "name": "Device Manager Devices",
         "description": "Device manager history from Chrysler vehicles (DeviceManagerDeviceList "
                        "bz2-compressed sqlite).",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/*DeviceManagerDeviceList.bz*',),
         "output_types": "standard",
         "artifact_icon": "smartphone",
-        "function": "get_devices",
     }
 }
 

--- a/scripts/artifacts/chrysler_logs.py
+++ b/scripts/artifacts/chrysler_logs.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Location_logs": {
+    "get_location_logs": {
         "name": "Location Logs",
         "description": "GPS location fixes (with accuracy, speed, course) parsed from Chrysler "
                        "JSR179 persistent logs.",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/persistentLogs/*/Log*',),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
         "artifact_icon": "map-pin",
-        "function": "get_location_logs",
     }
 }
 

--- a/scripts/artifacts/chrysler_phonebook.py
+++ b/scripts/artifacts/chrysler_phonebook.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "PhoneBook_Devices": {
+    "get_phone_book_devices": {
         "name": "PhoneBook Devices",
         "description": "Phonebook BT device list with connect/disconnect times from Chrysler "
                        "vehicles (PhoneBookDeviceList bz2-compressed sqlite).",
@@ -14,7 +14,6 @@ __artifacts_v2__ = {
         "paths": ('*/*PhoneBookDeviceList.bz*',),
         "output_types": "standard",
         "artifact_icon": "phone",
-        "function": "get_phone_book_devices",
     }
 }
 

--- a/scripts/artifacts/ford_Phonebook.py
+++ b/scripts/artifacts/ford_Phonebook.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Phonebook_contacts": {
+    "get_PhoneBook": {
         "name": "Phonebook Contacts",
         "description": "Phonebook contacts (name + number list) from Ford vehicles (BTPhonebook).",
         "author": "@JaysonU25",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/BTPhonebook*',),
         "output_types": "standard",
         "artifact_icon": "phone",
-        "function": "get_PhoneBook",
     }
 }
 

--- a/scripts/artifacts/ford_btdevices_history.py
+++ b/scripts/artifacts/ford_btdevices_history.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "BT_Device_History": {
+    "get_bt_device_hist": {
         "name": "BT Device History",
         "description": "Bluetooth connect/disconnect history from a Ford smartdevicelink.log.",
         "author": "@JaysonU25",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/*smartdevicelink.log',),
         "output_types": "standard",
         "artifact_icon": "bluetooth",
-        "function": "get_bt_device_hist",
     }
 }
 

--- a/scripts/artifacts/ford_devices_json.py
+++ b/scripts/artifacts/ford_devices_json.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Devices_from_json": {
+    "get_devices_json": {
         "name": "Devices from json",
         "description": "Bluetooth devices (MAC, serial, name) from a Ford devices.json.",
         "author": "@JaysonU25",
@@ -12,7 +12,6 @@ __artifacts_v2__ = {
         "paths": ('*/devices.json',),
         "output_types": "standard",
         "artifact_icon": "smartphone",
-        "function": "get_devices",
     }
 }
 
@@ -20,7 +19,7 @@ from scripts.ilapfuncs import artifact_processor
 
 
 @artifact_processor
-def get_devices(context):
+def get_devices_json(context):
     data_list = []
     source_path = ''
     for file_found in context.get_files_found():

--- a/scripts/artifacts/ford_fav_places.py
+++ b/scripts/artifacts/ford_fav_places.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Favorite_Places": {
+    "get_fav_places": {
         "name": "Favorite places",
         "description": "Saved/recent navigation places (label, address, coordinates) from Ford "
                        "places storage.",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/recents_storage', '*/favorites_storage'),
         "output_types": ['html', 'tsv', 'timeline', 'lava', 'kml'],
         "artifact_icon": "map-pin",
-        "function": "get_fav_places",
     }
 }
 

--- a/scripts/artifacts/ford_gps_speed_data.py
+++ b/scripts/artifacts/ford_gps_speed_data.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "GPS_Speed_Data": {
+    "get_ford_gps_speed_data": {
         "name": "GPS Speed Data",
         "description": "Dead-reckoning speed/heading data from Ford fdp logs.",
         "author": "@JaysonU25",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/*fdplog.np.txt*',),
         "output_types": "standard",
         "artifact_icon": "navigation",
-        "function": "get_ford_gps_speed_data",
     }
 }
 

--- a/scripts/artifacts/ford_vin_info.py
+++ b/scripts/artifacts/ford_vin_info.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Vin_Number": {
+    "get_info": {
         "name": "VIN",
         "description": "Vehicle Identification Number(s) from a Ford vin.txt.",
         "author": "@JaysonU25",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/vin.txt',),
         "output_types": "standard",
         "artifact_icon": "hash",
-        "function": "get_info",
     }
 }
 

--- a/scripts/artifacts/sal_data.py
+++ b/scripts/artifacts/sal_data.py
@@ -1,5 +1,5 @@
 __artifacts_v2__ = {
-    "Proj_Ctrl_Devices": {
+    "get_proj_ctrl_devices": {
         "name": "Chrysler - Proj Ctrl Devices",
         "description": "Device list (type, name, serial, BT MAC, port, attach count) from a "
                        "Chrysler sal_bkup/proj_ctrl SQLite database.",
@@ -13,7 +13,6 @@ __artifacts_v2__ = {
         "paths": ('*/sal_bkup/proj_ctrl',),
         "output_types": "standard",
         "artifact_icon": "list",
-        "function": "get_proj_ctrl_devices",
     }
 }
 


### PR DESCRIPTION
## Summary

VLEAPP counterpart of RLEAPP [#373](https://github.com/abrignoni/RLEAPP/pull/373): full v2 + context-form + LAVA/timestamp audit of every artifact. The audit found VLEAPP already fully modern on signatures and timestamps, but surfaced a **real runtime metadata bug** in the 11 files still using the legacy `"function"` metadata key — fixed here.

## The bug

`artifact_processor` resolves an artifact's metadata at runtime with `__artifacts_v2__[func.__name__]`. In 11 files the dict key differed from the function name (legacy shape: key `"Location_logs"` + `"function": "get_location_logs"`). The plugin loader's `"function"`-key fallback finds the callable, so these artifacts *ran* — but the wrapper's lookup returned `{}`, so at runtime they:

- reported under the **raw function name** (e.g. `get_location_logs` instead of "Location Logs") in HTML, TSV, timeline and LAVA
- lost **category, description and icon** (blank category group, no sidebar icon)
- lost `data_views` and their declared `output_types` (silently reverted to the full default)

Reproduced on HEAD: exactly these 11 artifacts miss the wrapper lookup; 0 after the fix.

## The fix

Rename each dict key to its function name and drop the `"function"` key — the canonical shape used across iLEAPP/ALEAPP/RLEAPP. `ford_devices_json`'s `get_devices` is renamed `get_devices_json` because artifact keys are global and `chrysler_devices` already claims `get_devices` (no cross-module references; verified).

| File | Old key → new key |
|---|---|
| chrysler_logs.py | `Location_logs` → `get_location_logs` |
| chrysler_devices.py | `Device_Manager_Devices` → `get_devices` |
| chrysler_phonebook.py | `PhoneBook_Devices` → `get_phone_book_devices` |
| Ford_Model.py | `Ford_Model` → `get_Model` |
| ford_Phonebook.py | `Phonebook_contacts` → `get_PhoneBook` |
| ford_btdevices_history.py | `BT_Device_History` → `get_bt_device_hist` |
| ford_devices_json.py | `Devices_from_json` → `get_devices_json` (+ function rename) |
| ford_fav_places.py | `Favorite_Places` → `get_fav_places` |
| ford_gps_speed_data.py | `GPS_Speed_Data` → `get_ford_gps_speed_data` |
| ford_vin_info.py | `Vin_Number` → `get_info` |
| sal_data.py | `Proj_Ctrl_Devices` → `get_proj_ctrl_devices` |

## Audit results (no changes needed elsewhere)

- ✅ All **74** plugins across 38 files already on `def f(context)` — 0 legacy four-arg signatures.
- ✅ No `wrap_text`/`textwrap` usage anywhere.
- ✅ Timestamps clean: no local-time `fromtimestamp()` feeding a `'datetime'` column; all `astimezone` uses are the guarded naive-vs-aware pattern; no missing `Z`-strips. Untagged time-like columns verified intentional (vehicle-local or year-less log times kept as text — e.g. `telematicsHyundai`'s `XXXX-MM-DD` log stamps, `chrysler_logs` local Date/Time, `systemappwtf`'s raw log `Date` — each per the local-timestamp rule; the true UTC columns beside them are tagged).
- ✅ No artifact file had changed since the 2026-06-29 conversion (only framework PRs #85/#87/#90).

## Validation

- ✅ PluginLoader: **74** plugins before and after; no resolution warnings.
- ✅ Wrapper-style metadata lookup resolves for **74/74** (was 63/74 on HEAD).
- ✅ `py_compile` clean; pylint `--disable=C,R` **10.00/10** on all 11 files.

Note: the LAVA table/key identifiers for these 11 artifacts change to the function names (display names in reports are unchanged — in fact restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
