### PR TITLE
docs: state Python 3.10 as the supported floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If you want to contribute hit me up on twitter: https://twitter.com/AlexisBrigno
 
 ## Requirements
 
-**Python 3.9 or above** (older versions of 3.x will also work with the exception of one or two modules)
+**Python 3.10 or above**
 
 ### Dependencies
 


### PR DESCRIPTION
Follow-up to the runtime contract job (#96).

## Problem

The README promised:

> **Python 3.9 or above** (older versions of 3.x will also work with the exception of one or two modules)

Neither half of that is tested. CI runs 3.10, 3.11 and 3.12, and Python 3.9 reached end of life in October 2025, so the claim about older 3.x releases is a promise nothing verifies.

## Fix

```
**Python 3.10 or above**
```

Matches ALEAPP's wording, so the cores agree on the floor and the docs match what CI actually enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)