### PR TITLE
docs: correct the \bhabit stem rationale in the claim-language check

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -86,11 +86,15 @@ ARTIFACTS_DIR = os.path.join(REPO_ROOT, 'scripts', 'artifacts')
 # The stems below are left UNCLOSED on purpose so inflections still match:
 #   \bcomplete -> complete, completeness, completely
 #   \breliable -> reliable and its compounds
-#   \bhabit    -> habit, habits
-# The cost of the open \bhabit is that it also matches "habitat"; no artifact in
-# this repo uses that word today, and this spelling is kept deliberately in sync
-# with the iLEAPP and ALEAPP implementations of the same check. If a
-# habitat-related artifact ever lands, close it to \bhabits?\b rather than
+#   \bhabit    -> habit, habits, habitual, habitually
+# The open \bhabit is kept for "habitual", the inference word most likely to turn
+# up in a description of app usage data; the closed spelling \bhabits?\b does not
+# catch it. The cost is that the open stem also matches "habitat", which no
+# artifact name or description in this repo uses today (verified by grep over
+# scripts/artifacts). ALEAPP's implementation of this check uses the closed
+# \bhabits?\b and has since it was written, so the two spellings differ on
+# purpose -- they are not, and have never been, kept in sync. If a
+# habitat-related artifact ever lands here, close the stem rather than
 # allowlisting the artifact.
 CLAIM_PATTERN = re.compile(
     r'\ball\b'


### PR DESCRIPTION
## What

The comment above `CLAIM_PATTERN` in [admin/scripts/check_claim_language.py](admin/scripts/check_claim_language.py) justified the open `\bhabit` stem by saying the spelling "is kept deliberately in sync with the iLEAPP and ALEAPP implementations of the same check".

The ALEAPP half of that is false. ALEAPP uses the **closed** `\bhabits?\b`, and has in every revision of that file since it was written. Its own comment says the closed form is deliberate, because the open stem also matches "habitat". Only the iLEAPP half was true.

## Change

Comment only. `CLAIM_PATTERN` is byte-for-byte unchanged — the open `\bhabit` stays.

The rationale now:

- justifies the open stem on its own merits: it catches "habitual" and "habitually", the inference words most likely to appear in a description of app usage data, which the closed spelling misses
- keeps the "habitat" cost, with a note on how it was verified (grep over `scripts/artifacts`)
- records ALEAPP's closed spelling as a deliberate **divergence** rather than a sync

The same false line was corrected in iLEAPP as abrignoni/iLEAPP#1857; this mirrors that wording.

## Verification

- `grep -rni habit scripts/artifacts/` → no matches at all, so no name or description uses "habitat" and the stated cost is accurate
- `python3 -m py_compile admin/scripts/check_claim_language.py` → clean
- `python3 admin/scripts/check_claim_language.py` → exit 0, "Checked 38 artifact module(s): no unsupported claim language"
- `python3 admin/scripts/lint_changed.py --base-ref origin/main admin/scripts/check_claim_language.py` → PASS, 0 new warnings

ALEAPP is intentionally left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)