### PR TITLE
Harden zip extraction against member names Windows cannot write

### DIFF
--- a/admin/test/scripts/test_extraction_illegal_filenames.py
+++ b/admin/test/scripts/test_extraction_illegal_filenames.py
@@ -1,0 +1,137 @@
+"""Guard extraction against archive members whose names Windows cannot write.
+
+Device extractions can carry files with ASCII control characters in their
+names; an iOS 26 full file system image held chronod icon entries like
+'╞¼\\x01\\x0e::com.apple.siri.heic', and this FileSeekerZip code is shared
+across the LEAPP family. ZipFile.extract() only replaces a fixed set of
+printable characters (:<>|"?*) and only on Windows, so the control bytes
+reach the OS untouched and open() fails with [Errno 22] Invalid argument.
+In the iLEAPP case run that surfaced this, every affected member logged
+'Could not write file to filesystem' and was silently absent from the
+extraction; worse, the failing member appended the *previous* member's path
+to the seeker's result list because `extracted_path` still held its stale
+value.
+
+These tests pin the fix: sanitize_file_path()/sanitize_file_name() treat
+control characters as illegal, and FileSeekerZip writes such members manually
+to a sanitized path inside the data folder on every platform.
+"""
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from leapp_functions.app.platform import (  # pylint: disable=wrong-import-position
+    sanitize_file_name, sanitize_file_path, validate_filename)
+from scripts.search_files import FileSeekerZip  # pylint: disable=wrong-import-position
+
+# The real member name observed in an iOS 26 full file system extraction.
+ICON_MEMBER = ('/private/var/mobile/Library/chronod/icons/'
+               '╖¬\x01\x0e::com.apple.siri.heic')
+ICON_CONTENT = b'not really a heic'
+
+
+def _has_control_chars(text):
+    return any(ord(c) < 0x20 or ord(c) == 0x7f for c in text)
+
+
+class TestSanitizeControlChars(unittest.TestCase):
+    """The sanitize helpers must replace what Windows rejects with EINVAL."""
+
+    def test_file_path_replaces_control_chars_but_keeps_separators(self):
+        cleaned = sanitize_file_path('icons/\x01\x0e::a.heic')
+        self.assertEqual(cleaned, 'icons/__::a.heic'.replace(':', '_'))
+        self.assertIn('/', cleaned)
+        self.assertFalse(_has_control_chars(cleaned))
+
+    def test_file_name_replaces_control_chars(self):
+        self.assertEqual(sanitize_file_name('a\x00b\x1fc\x7fd'), 'a_b_c_d')
+
+    def test_printable_illegal_chars_still_replaced(self):
+        self.assertEqual(sanitize_file_name('a:b*c?d'), 'a_b_c_d')
+
+    def test_unicode_stays_untouched(self):
+        self.assertEqual(sanitize_file_name('╖¬ café'),
+                         '╖¬ café')
+
+    def test_validate_filename_rejects_control_chars_without_crashing(self):
+        is_valid, message = validate_filename('output\x01folder')
+        self.assertFalse(is_valid)
+        self.assertTrue(message)
+
+
+class TestFileSeekerZipIllegalNames(unittest.TestCase):
+    """A zip member with control characters in its name must still extract."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.data_folder = os.path.join(self.tmpdir, 'data')
+        os.makedirs(self.data_folder)
+        self.zip_path = os.path.join(self.tmpdir, 'fs-full.zip')
+        with zipfile.ZipFile(self.zip_path, 'w') as z:
+            z.writestr(ICON_MEMBER, ICON_CONTENT)
+            z.writestr('/private/var/mobile/Library/chronod/icons/plain.heic',
+                       b'plain content')
+        self.seeker = FileSeekerZip(self.zip_path, self.data_folder)
+
+    def tearDown(self):
+        self.seeker.cleanup()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_both_members_are_extracted(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        self.assertEqual(len(paths), 2)
+        for path in paths:
+            self.assertTrue(os.path.isfile(path), path)
+
+    def test_extracted_path_carries_no_illegal_characters(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')]
+        self.assertEqual(len(sanitized), 1)
+        relative = os.path.relpath(sanitized[0], self.data_folder)
+        self.assertFalse(_has_control_chars(relative))
+        self.assertNotIn(':', relative)
+
+    def test_extracted_content_is_intact(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')][0]
+        with open(sanitized, 'rb') as f:
+            self.assertEqual(f.read(), ICON_CONTENT)
+
+    def test_extraction_stays_inside_the_data_folder(self):
+        """Member names lead with '/'; a naive join would escape data_folder."""
+        for path in self.seeker.search('*/chronod/icons/*'):
+            self.assertTrue(
+                os.path.realpath(path).startswith(
+                    os.path.realpath(self.data_folder) + os.sep), path)
+
+    def test_file_info_is_recorded_for_sanitized_members(self):
+        paths = self.seeker.search('*/chronod/icons/*')
+        sanitized = [p for p in paths if p.endswith('com.apple.siri.heic')][0]
+        self.assertIn(sanitized, self.seeker.file_infos)
+        self.assertEqual(self.seeker.file_infos[sanitized].source_path, ICON_MEMBER)
+
+    def test_dot_dot_segments_cannot_escape_the_data_folder(self):
+        traversal_zip = os.path.join(self.tmpdir, 'traversal.zip')
+        with zipfile.ZipFile(traversal_zip, 'w') as z:
+            z.writestr('icons/../../../evil\x01.txt', b'x')
+        seeker = FileSeekerZip(traversal_zip, self.data_folder)
+        try:
+            paths = seeker.search('**')
+            self.assertTrue(paths)
+            for path in paths:
+                self.assertTrue(
+                    os.path.realpath(path).startswith(
+                        os.path.realpath(self.data_folder) + os.sep), path)
+        finally:
+            seeker.cleanup()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/leapp_functions/app/platform.py
+++ b/leapp_functions/app/platform.py
@@ -17,14 +17,24 @@ ILLEGAL_FILENAME_CHARS = {
     '\n': '\\n newline',
 }
 
+# ASCII control characters (0x00-0x1F, 0x7F): Windows rejects them in paths
+# with EINVAL, so they must be sanitized alongside the printable illegal set.
+# iOS extractions really do contain them, e.g. chronod icon files named
+# '╞¼\x01\x0e::com.apple.siri.heic'.
+_CONTROL_CHARS_PATTERN = '\\x00-\\x1f\\x7f'
+
+
+def _is_control_char(char):
+    return ord(char) < 0x20 or ord(char) == 0x7f
+
 
 def _illegal_filename_char_pattern():
-    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + ']'
+    return '[' + re.escape(''.join(ILLEGAL_FILENAME_CHARS)) + _CONTROL_CHARS_PATTERN + ']'
 
 
 def _illegal_filepath_char_pattern():
     chars = ''.join(c for c in ILLEGAL_FILENAME_CHARS if c not in '\\/')
-    return '[' + re.escape(chars) + ']'
+    return '[' + re.escape(chars) + _CONTROL_CHARS_PATTERN + ']'
 
 
 def format_illegal_filename_chars(chars):
@@ -36,8 +46,10 @@ def format_illegal_filename_chars(chars):
 
 def illegal_chars_in_filename(filename):
     '''Return sorted illegal characters present in filename.'''
-    return sorted({c for c in filename if c in ILLEGAL_FILENAME_CHARS},
-                  key=lambda c: list(ILLEGAL_FILENAME_CHARS).index(c))
+    order = {char: index for index, char in enumerate(ILLEGAL_FILENAME_CHARS)}
+    return sorted({c for c in filename
+                   if c in ILLEGAL_FILENAME_CHARS or _is_control_char(c)},
+                  key=lambda c: order.get(c, len(order)))
 
 
 def sanitize_file_path(filename, replacement_char='_'):

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -290,8 +290,7 @@ class FileSeekerZip(FileSeekerBase):
             if pat(root + normcase(member)) is not None:
                 if member not in self.copied or force:
                     try:
-                        # already replaces illegal chars with _ when exporting
-                        extracted_path = self.zip_file.extract(member, path=self.data_folder)
+                        extracted_path = self._extract_member(member)
                         f = self.zip_file.getinfo(member)
                         creation_date, modification_date = self.decode_extended_timestamp(f.extra)
                         file_info = FileInfo(member, creation_date, modification_date)
@@ -302,6 +301,7 @@ class FileSeekerZip(FileSeekerBase):
                         self.copied[member] = extracted_path
                     except OSError as ex:
                         logfunc(f'Could not write file to filesystem, path was {member} ' + str(ex))
+                        continue
                 else:
                     extracted_path = self.copied[member]
                 pathlist.append(extracted_path)
@@ -310,6 +310,29 @@ class FileSeekerZip(FileSeekerBase):
                     return extracted_path
         self.searched[filepattern] = pathlist
         return pathlist
+
+    def _extract_member(self, member):
+        """Extract one member, sanitizing names ZipFile.extract() cannot write.
+
+        ZipFile.extract() only replaces a fixed set of printable characters
+        (:<>|"?*) and only on Windows; ASCII control characters in the stored
+        name (present in real iOS extractions, e.g. chronod icon files) reach
+        the OS untouched and Windows rejects them with EINVAL. Members whose
+        names need sanitizing are written out manually to a cleaned path.
+        """
+        clean_member = sanitize_file_path(member)
+        if clean_member == member:
+            return self.zip_file.extract(member, path=self.data_folder)
+        parts = [part for part in clean_member.split('/')
+                 if part not in ('', '.', '..')]
+        extracted_path = os.path.join(self.data_folder, *parts)
+        if member.endswith('/'):
+            os.makedirs(extracted_path, exist_ok=True)
+        else:
+            os.makedirs(os.path.dirname(extracted_path), exist_ok=True)
+            with self.zip_file.open(member) as fin, open(extracted_path, 'wb') as fout:
+                fout.write(fin.read())
+        return extracted_path
 
     def cleanup(self):
         self.zip_file.close()


### PR DESCRIPTION
Port of iLEAPP [commit 5ee6a09e](https://github.com/abrignoni/iLEAPP/commit/5ee6a09e967afae44211dd1e0eb1b148dd5dfc0b) (PR #1879). The failing code path is shared across the LEAPP family.

## FileSeekerZip: members with control characters in their names
`ZipFile.extract()` only replaces a fixed set of printable characters (`:<>|"?*`) and only on Windows, so ASCII control characters in a member name (observed in a real iOS 26 extraction: chronod icon files like `╞¼\x01\x0e::com.apple.siri.heic`) reach the OS untouched and Windows rejects them with EINVAL. The member then silently went missing from the extraction, and worse, the failing member appended the *previous* member's stale `extracted_path` to the seeker's result list. Such members are now written manually to a sanitized path inside the data folder on every platform, and `sanitize_file_path`/`sanitize_file_name` treat control characters (0x00-0x1F, 0x7F) as illegal.

## Tests
11 new tests in `admin/test/scripts/test_extraction_illegal_filenames.py` (synthetic zips only, no image data), including a path-traversal guard for the manual extraction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)