### PR TITLE
Escape the evidence media name in report media tags

### DIFF
--- a/scripts/html_safe.py
+++ b/scripts/html_safe.py
@@ -1,0 +1,133 @@
+"""Helpers for safely emitting evidence-derived values into ``html_columns`` cells.
+
+Columns listed in an artifact's ``__artifacts_v2__`` ``html_columns`` are written to
+the HTML report **without** the framework's ``html.escape`` (see
+``scripts/artifact_report.py`` ``write_artifact_data_table`` -- the ``html_no_escape``
+branch). Any evidence-derived text placed in such a cell is therefore an
+HTML/JavaScript injection sink: malicious content in a parsed return renders live in
+the examiner's report (stored XSS, CWE-79).
+
+Route every evidence-derived value in an ``html_columns`` cell through these helpers so
+the dynamic parts are escaped while the tool's own structural markup (``<br>``,
+``<table>``) is preserved.
+
+**A report links to nothing outside its own folder.** A remote destination in a
+report is a disclosure channel: an ``<img src="https://...">`` is fetched the moment
+the report is opened, with no click, which tells whoever controls that host that the
+account is under examination, when, and from which IP address. An ``<a href>`` needs a
+click but reaches the same place. Reports are read on analyst workstations and mailed
+to counsel, so no ``href`` or ``src`` may leave the report folder -- not ``http``,
+``https``, ``ftp``, and not ``mailto``/``tel``, which hand the subject's own address or
+number to a mail client or dialer.
+
+Evidence URLs are still *evidence*, so nothing is dropped: they are rendered as escaped
+text the examiner can read and copy. Only the anchor goes away. Report-relative
+destinations -- ``media/<file>`` thumbnails, files an artifact writes beside the report
+-- stay clickable through ``safe_local_link()``; they resolve offline and reach nothing.
+"""
+
+import html
+from urllib.parse import urlparse, quote
+
+
+def esc(value):
+    """HTML-escape a single evidence value for safe use in text or an attribute.
+
+    ``None`` becomes ``''``. ``quote=True`` escapes ``"`` and ``'`` as well, so the
+    result is safe in both element-text and double-quoted-attribute contexts.
+    """
+    if value is None:
+        return ''
+    return html.escape(str(value), quote=True)
+
+
+def safe_url(url, text=None, target=None):      # pylint: disable=unused-argument
+    """Render an evidence URL as escaped text. **Never returns a link.**
+
+    A URL read out of an extraction names a host chosen by whoever wrote the data, so
+    it is exactly the destination a report must not reach; see the module docstring.
+    The URL itself is evidence and is preserved verbatim as escaped text, so an
+    examiner can read it, copy it, and open it deliberately elsewhere.
+
+    ``text`` overrides the visible string when the caller has a better label than the
+    raw URL. ``target`` is accepted and ignored: it exists so the call sites that
+    passed it before this became text-only keep working.
+    """
+    url = '' if url is None else str(url).strip()
+    return esc(text if text is not None else url)
+
+
+def _is_report_relative(path, allow_parent=False):
+    """True when ``path`` names something reachable from the report folder.
+
+    Rejects a URL scheme, a protocol-relative ``//host`` and an absolute path, so a
+    crafted media name cannot turn a report cell into a remote fetch. ``..`` is
+    rejected too unless ``allow_parent`` is set: media_to_html() genuinely emits
+    ``../data/...`` to reach the extraction folder next to the report, and that is a
+    deliberate part of the report layout rather than an escape.
+    """
+    if path.startswith(('/', '\\')):
+        return False
+    normalized = path.replace('\\', '/')
+    if normalized.startswith('//'):
+        return False
+    if not allow_parent and '..' in normalized.split('/'):
+        return False
+    try:
+        if urlparse(path).scheme:
+            return False
+    except ValueError:
+        return False
+    return True
+
+
+def safe_local_path(path, allow_parent=False):
+    """Percent-encode a report-relative path for use in an ``href``/``src`` attribute.
+
+    Returns ``''`` when the path is not report-relative, so a crafted media filename
+    can neither point the report at a remote host nor reach outside the report folder.
+    The encoded result is HTML-escaped as well, so it is safe inside a quoted
+    attribute. Use this for the attribute value; use safe_local_link() when you want
+    the whole anchor.
+    """
+    path = '' if path is None else str(path).strip()
+    if not path or not _is_report_relative(path, allow_parent):
+        return ''
+    return esc(quote(path, safe='/.'))
+
+
+def safe_local_link(path, text=None):
+    """Build an ``<a href>`` to a file inside the report folder.
+
+    This is the only helper that still emits an anchor. The destination must be
+    report-relative -- no scheme, no protocol-relative ``//host``, no absolute path,
+    and no ``..`` escaping the folder -- so following it can never leave the report.
+    Anything else is returned as escaped text with no anchor.
+    """
+    path = '' if path is None else str(path).strip()
+    label = esc(text if text is not None else path)
+    if not path or not _is_report_relative(path):
+        return label
+    return f'<a href="{esc(path)}" target="_blank">{label}</a>'
+
+
+def safe_join(values, sep='<br>'):
+    """Escape each evidence value and join with a tool-controlled separator.
+
+    The separator is emitted verbatim (it is tool-owned markup, default ``<br>``);
+    every joined value is escaped.
+    """
+    return sep.join(esc(v) for v in values)
+
+
+def safe_source(text):
+    """Escape an evidence text/document body for display as source.
+
+    Real newlines become ``<br>`` for readability *after* escaping, so any markup in
+    the evidence (including a literal ``<br>``) is shown inert as text. Use for
+    Tier-1 raw bodies -- message/email bodies, whole return pages, notes -- per the
+    escape-to-source policy.
+    """
+    if text is None:
+        return ''
+    return esc(text).replace('\n', '<br>')

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -45,6 +45,7 @@ from functools import wraps
 
 # LEAPP version unique imports
 from typing import Pattern
+from scripts.html_safe import esc, safe_local_path
 from scripts.lavafuncs import lava_process_artifact, lava_insert_sqlite_data, lava_get_media_item, \
     lava_insert_sqlite_media_item, lava_insert_sqlite_media_references, lava_get_media_references, \
     lava_get_full_media_info
@@ -356,20 +357,25 @@ def html_media_tag(media_path, mimetype, style, title=''):
         filename = Path(source).name
         return f"media/{filename}"
 
-    filename = Path(media_path).name
-    media_path = quote(relative_paths(media_path))
+    # The media name comes from the evidence, so every place it is emitted is
+    # escaped: percent-encoded in src/href by safe_local_path(), which also refuses a
+    # target that would leave the report folder, and HTML-escaped in title= and in the
+    # fallback link text. Before this, a crafted attachment filename broke out of the
+    # title attribute and ran in the examiner's report (CWE-79).
+    filename = esc(Path(media_path).name)
+    media_path = safe_local_path(relative_paths(media_path))
 
-    if mimetype == None:
+    if mimetype is None:
         mimetype = ''
     if 'video' in mimetype:
         thumb = f'<video width="320" height="240" controls="controls"><source src="{media_path}" type="video/mp4" preload="none">Your browser does not support the video tag.</video>'
     elif 'image' in mimetype:
-        image_style = style if style else "max-height:300px; max-width:400px;"
-        thumb = f'<a href="{media_path}" target="_blank"><img title="{title}"  src="{media_path}" style="{image_style}"></img></a>'
+        image_style = esc(style) if style else "max-height:300px; max-width:400px;"
+        thumb = f'<a href="{media_path}" target="_blank"><img title="{esc(title)}"  src="{media_path}" style="{image_style}"></img></a>'
     elif 'audio' in mimetype:
         thumb = f'<audio controls><source src="{media_path}" type="audio/ogg"><source src="{media_path}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
     else:
-        thumb = f'<a href="{media_path}" target="_blank"> Link to {filename} file</>'
+        thumb = f'<a href="{media_path}" target="_blank"> Link to {filename} file</a>'
     return thumb
 
 def get_data_list_with_media(media_header_info, data_list):
@@ -916,17 +922,23 @@ def media_to_html(media_path, files_found, report_folder):
             source = relative_paths(str(source), splitter)
 
         mimetype = guess_mime(match)
-        if mimetype == None:
+        if mimetype is None:
             mimetype = ''
+
+        # allow_parent: relative_paths() above deliberately emits ../data/... to reach
+        # the extraction folder beside the report. The evidence filename in the
+        # fallback link text is escaped -- it used to be interpolated raw.
+        source = safe_local_path(source, allow_parent=True)
+        filename = esc(filename)
 
         if 'video' in mimetype:
             thumb = f'<video width="320" height="240" controls="controls"><source src="{source}" type="video/mp4" preload="none">Your browser does not support the video tag.</video>'
         elif 'image' in mimetype:
-            thumb = f'<a href="{source}" target="_blank"><img src="{source}"width="300"></img></a>'
+            thumb = f'<a href="{source}" target="_blank"><img src="{source}" width="300"></img></a>'
         elif 'audio' in mimetype:
             thumb = f'<audio controls><source src="{source}" type="audio/ogg"><source src="{source}" type="audio/mpeg">Your browser does not support the audio element.</audio>'
         else:
-            thumb = f'<a href="{source}" target="_blank"> Link to {filename} file</>'
+            thumb = f'<a href="{source}" target="_blank"> Link to {filename} file</a>'
     return thumb
 
 


### PR DESCRIPTION
## Why

`html_media_tag()` interpolated the media item's name straight into the `title=` attribute of the `<img>` it builds, and both it and `media_to_html()` dropped the raw evidence filename into the fallback anchor text. A crafted attachment filename closed the attribute and ran in the examiner's report (stored XSS, CWE-79).

GHSA-45q2-q93c-cfv2 fixed the artifact-side `html_columns` builders in July and explicitly deferred this one. It reaches **every media column tool-wide** — including in cores where no artifact declares `html_columns` by hand, because the framework adds media columns to the no-escape list itself.

**This core had no `scripts/html_safe.py` at all.** It is the one core the July GHSA-45q2-q93c-cfv2 work never reached, so the file is added here whole. No VLEAPP artifact declares `html_columns` today, but the framework adds media columns to the no-escape list itself, so the media tags were a live sink regardless.

## What changed

`safe_local_path()` is added to `html_safe.py`. It percent-encodes a report-relative path for an `href`/`src` attribute and returns `''` for anything that is not report-relative, so a crafted media name can neither point the report at a remote host nor climb out of the report folder. `_is_report_relative()` is factored out of `safe_local_link()` so both helpers apply one rule.

`media_to_html()` passes `allow_parent=True`. Its `relative_paths()` deliberately emits `../data/...` to reach the extraction folder beside the report — part of the report layout, not an escape — so that case is permitted explicitly rather than silently.

In both functions the media name is now `esc()`'d in `title=` and in the fallback link text, the image style is `esc()`'d, and the malformed `</>` that closed the fallback anchor is now `</a>`.

## Before / after

A media filename of `x" onerror=alert(1) t=".jpg`:

```
before: <img title="x" onerror=alert(1) t=".jpg" src=...>   <- breaks out, fires
after:  <img title="x&quot; onerror=alert(1) t=&quot;.jpg" src=...>  <- inert
```

The evidence is fully preserved in both cases; only the breakout is gone.

## Validation

- `py_compile` clean; `lint_changed` reports no new warnings
- unit tests OK; `PluginLoader` loads every plugin
- injection payload renders escaped with no attribute breakout
- a `<script>` filename renders inert in the fallback link
- a normal HEIC still renders its thumbnail unchanged
- a style carrying `" onload="` is escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)