### PR TITLE
feat: add null_absent_columns() for cross-version schema tolerance

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -747,6 +747,93 @@ def does_table_exist_in_db(path, table_name):
             logfunc(f"Query error, query={query} Error={str(ex)}")
     return False
 
+def null_absent_columns(path, query):
+    '''Replace references to columns the database lacks with NULL.
+
+    Apps add columns between releases, so a query written against a newer store
+    names columns an older one does not have and the whole statement fails with
+    "no such column", returning nothing. Substituting NULL keeps every column in
+    place, which matters because artifacts consume rows positionally.
+
+    Only references the query itself qualifies or that resolve to exactly one
+    table in the FROM/JOIN list are touched, so an ambiguous name is left alone
+    rather than guessed at. Returns the query unchanged if the schema cannot be
+    read.
+    '''
+    db = open_sqlite_db_readonly(path)
+    if not db:
+        return query
+    try:
+        tables = [row[0] for row in db.execute(
+            "SELECT name FROM sqlite_master WHERE type IN ('table','view')")]
+        columns = {name.upper(): {row[1].upper() for row in
+                                  db.execute(f'PRAGMA table_info("{name}")')}
+                   for name in tables}
+    except sqlite3.Error as ex:
+        logfunc(f'Could not read schema of {path}: {ex}')
+        return query
+
+    # alias (and bare table name) -> table, taken from the FROM and JOIN clauses
+    aliases = {}
+    used = []
+    for match in re.finditer(
+            r'\b(?:FROM|JOIN)\s+([A-Za-z_][A-Za-z_0-9]*)(?:\s+(?:AS\s+)?([A-Za-z_][A-Za-z_0-9]*))?',
+            query, re.IGNORECASE):
+        table, alias = match.group(1), match.group(2)
+        if table.upper() not in columns:
+            continue
+        used.append(table.upper())
+        aliases[table.upper()] = table.upper()
+        if alias and alias.upper() not in ('ON', 'WHERE', 'GROUP', 'ORDER', 'LEFT',
+                                           'INNER', 'OUTER', 'CROSS', 'JOIN', 'USING'):
+            aliases[alias.upper()] = table.upper()
+
+    absent = set()
+    for match in re.finditer(r'\b([A-Za-z_][A-Za-z_0-9]*)\.([A-Za-z_][A-Za-z_0-9]*)\b', query):
+        table = aliases.get(match.group(1).upper())
+        if table and match.group(2).upper() not in columns[table]:
+            absent.add(match.group(0))
+
+    # Bare column names: only safe when exactly one table in play defines the name.
+    if len(set(used)) >= 1:
+        qualified = {reference.split('.', 1)[1].upper() for reference in absent}
+        for match in re.finditer(r'(?<![.\w])([A-Za-z_][A-Za-z_0-9]*)(?![\w.(])', query):
+            name = match.group(1).upper()
+            if (name in qualified or name in aliases or name in columns
+                    or not name.startswith('Z')):
+                continue
+            holders = [table for table in set(used) if name in columns[table]]
+            if not holders and any(name not in columns[table] for table in set(used)):
+                absent.add(match.group(1))
+
+    # A bare NULL also drops the output column's name, and artifacts read rows by
+    # name, so keep the name with an alias wherever the reference is a select item
+    # in its own right. Inside an expression the enclosing alias already names the
+    # column, so a plain NULL is correct there.
+    # One pass, so an alias inserted for one reference cannot be rewritten while
+    # handling the next. A bare NULL also drops the output column's name and
+    # artifacts read rows by name, so keep the name wherever the reference is a
+    # select item in its own right; inside an expression the enclosing alias
+    # already names the column and a plain NULL is right.
+    if absent:
+        pattern = re.compile(
+            r'(?<![\w.])(' + '|'.join(re.escape(reference) for reference in
+                                      sorted(absent, key=len, reverse=True)) + r')\b'
+            r'(?P<tail>\s*(?:,|$)|\s+(?i:FROM)\b)?')
+
+        def _replace(match):
+            tail = match.group('tail')
+            if tail is None:
+                return 'NULL'
+            name = match.group(1).split('.', 1)[-1]
+            return f'NULL AS {name}{tail}'
+
+        query = pattern.sub(_replace, query)
+    if absent:
+        logfunc(f'{os.path.basename(path)}: column(s) absent from this version are reported '
+                f'empty: {", ".join(sorted(absent))}')
+    return query
+
 def does_view_exist_in_db(path, table_name):
     '''Checks if a table with specified name exists in an sqlite db'''
     db = open_sqlite_db_readonly(path)


### PR DESCRIPTION
Apps add columns between releases. A query written against a newer store names a column an older one lacks, SQLite fails the **whole statement** with `no such column`, and the artifact reports nothing instead of the rows it could have returned. One missing column costs every row, and it fails quietly: an artifact that returns nothing looks exactly like a feature the user never used.

`null_absent_columns(path, query)` substitutes `NULL` for column references the database does not have.

Ported verbatim from iLEAPP, where it took ten modules from **132 error lines to 1 across 21 corpora** and recovered rows on 56 artifact/corpus pairs ([iLEAPP #1912](https://github.com/abrignoni/iLEAPP/pull/1912)).

## Three properties that are not obvious, and each cost a debugging round

1. **It emits `NULL AS <name>`, not a bare `NULL`,** where the reference is a select item in its own right. A bare NULL also drops the output column's *name*, and artifacts read rows by name, so the SQL starts succeeding and the artifact then dies on `record['ZFOO']` with `IndexError: No item with that key`. Inside an expression the enclosing alias already names the column, so a plain NULL is correct there.
2. **The substitution is a single pass** over one compiled alternation. A per-reference loop rewrites the alias it just inserted and produces `NULL AS NULL`. A sentinel does not save it either, because a non-word sentinel still satisfies the `(?<![\w.])` lookbehind.
3. **Column comparison is case-insensitive.** A case-sensitive check reported 9 missing columns on one Photos.sqlite where only 2 were real.

It resolves table aliases from the FROM/JOIN clauses, only touches references it can attribute to exactly one table, and returns the query unchanged if the schema cannot be read.

## Scope

**No call sites in this repo yet.** This makes the helper available; it does not change any artifact's behaviour. Wiring it into specific artifacts is a separate change that deserves its own before/after corpus sweep.

Verified the ported function behaves identically to iLEAPP's in this core: same 97 rows on a real ThreeBars.sqlite missing `ZLOWQUALITY`, column name preserved, value `None`.

Worth noting for context: these five `ilapfuncs.py` files are less synchronised than "shared core" suggests — 43 top-level functions are common to all five, with 7 to 28 unique to each. So this is a deliberate addition rather than a sync.

`check_claim_language.py`, `check_html_safety.py` and `lint_changed.py` pass. Lint reports one *fewer* warning than before, because the helper uses `re` and silenced a pre-existing unused-import warning.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>