### PR TITLE
fix: collect what only artifacts import into frozen builds

### DIFF
--- a/scripts/pyinstaller/vleapp.spec
+++ b/scripts/pyinstaller/vleapp.spec
@@ -1,5 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 block_cipher = None
 
 a = Analysis(
@@ -7,7 +9,23 @@ a = Analysis(
     pathex=['.\\scripts\\artifacts'],
     binaries=[],
     datas=[('..\\', '.\\scripts')],
-    hiddenimports=[],
+    hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. leapp_functions.data_sources
+        # is imported only by artifacts, so without this it is missing from the
+        # frozen build and every artifact importing it dies at load.
+        *collect_submodules('leapp_functions'),
+        # Stdlib that only artifacts import; PyInstaller prunes stdlib it cannot
+        # see used, so these are absent from the frozen build without this list
+        # (the local frozen smoke run died on xml.etree).
+        'bz2',
+        'gzip',
+        'tarfile',
+        'xml.etree.ElementTree',
+    ],
     hookspath=['.\\'],
     runtime_hooks=[],
     excludes=[],

--- a/scripts/pyinstaller/vleappGUI.spec
+++ b/scripts/pyinstaller/vleappGUI.spec
@@ -1,5 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 block_cipher = None
 
 a = Analysis(
@@ -7,7 +9,23 @@ a = Analysis(
     pathex=['..\\scripts\\artifacts'],
     binaries=[],
     datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets')],
-    hiddenimports=[],
+    hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. leapp_functions.data_sources
+        # is imported only by artifacts, so without this it is missing from the
+        # frozen build and every artifact importing it dies at load.
+        *collect_submodules('leapp_functions'),
+        # Stdlib that only artifacts import; PyInstaller prunes stdlib it cannot
+        # see used, so these are absent from the frozen build without this list
+        # (the local frozen smoke run died on xml.etree).
+        'bz2',
+        'gzip',
+        'tarfile',
+        'xml.etree.ElementTree',
+    ],
     hookspath=['.\\'],
     runtime_hooks=[],
     excludes=[],

--- a/scripts/pyinstaller/vleappGUI_Linux.spec
+++ b/scripts/pyinstaller/vleappGUI_Linux.spec
@@ -1,5 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../vleappGUI.py'],
     pathex=['../scripts/artifacts'],
@@ -9,6 +11,21 @@ a = Analysis(
         ('../../assets', 'assets'),
         ('../../leapp_functions', 'leapp_functions')],
     hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. leapp_functions.data_sources
+        # is imported only by artifacts, so without this it is missing from the
+        # frozen build and every artifact importing it dies at load.
+        *collect_submodules('leapp_functions'),
+        # Stdlib that only artifacts import; PyInstaller prunes stdlib it cannot
+        # see used, so these are absent from the frozen build without this list
+        # (the local frozen smoke run died on xml.etree).
+        'bz2',
+        'gzip',
+        'tarfile',
+        'xml.etree.ElementTree',
         'PIL._tkinter_finder',
     ],
     hookspath=[],

--- a/scripts/pyinstaller/vleappGUI_macOS.spec
+++ b/scripts/pyinstaller/vleappGUI_macOS.spec
@@ -1,11 +1,29 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../vleappGUI.py'],
     pathex=['../scripts/artifacts'],
     binaries=[],
     datas=[('../', 'scripts'), ('../../assets', 'assets')],
-    hiddenimports=[],
+    hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. leapp_functions.data_sources
+        # is imported only by artifacts, so without this it is missing from the
+        # frozen build and every artifact importing it dies at load.
+        *collect_submodules('leapp_functions'),
+        # Stdlib that only artifacts import; PyInstaller prunes stdlib it cannot
+        # see used, so these are absent from the frozen build without this list
+        # (the local frozen smoke run died on xml.etree).
+        'bz2',
+        'gzip',
+        'tarfile',
+        'xml.etree.ElementTree',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/scripts/pyinstaller/vleapp_Linux.spec
+++ b/scripts/pyinstaller/vleapp_Linux.spec
@@ -1,11 +1,29 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../vleapp.py'],
     pathex=['../scripts/artifacts'],
     binaries=[],
     datas=[('../', 'scripts')],
-    hiddenimports=[],
+    hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. leapp_functions.data_sources
+        # is imported only by artifacts, so without this it is missing from the
+        # frozen build and every artifact importing it dies at load.
+        *collect_submodules('leapp_functions'),
+        # Stdlib that only artifacts import; PyInstaller prunes stdlib it cannot
+        # see used, so these are absent from the frozen build without this list
+        # (the local frozen smoke run died on xml.etree).
+        'bz2',
+        'gzip',
+        'tarfile',
+        'xml.etree.ElementTree',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],

--- a/scripts/pyinstaller/vleapp_macOS.spec
+++ b/scripts/pyinstaller/vleapp_macOS.spec
@@ -1,11 +1,29 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+from PyInstaller.utils.hooks import collect_submodules
+
 a = Analysis(
     ['../../vleapp.py'],
     pathex=['../scripts/artifacts'],
     binaries=[],
     datas=[('../', 'scripts')],
-    hiddenimports=[],
+    hiddenimports=[
+        # Artifacts are bundled as data files and imported from disk at runtime,
+        # so PyInstaller's import-graph analysis never sees what they import.
+        # hook-plugin_loader.py was meant to cover this but targets a bare
+        # 'plugin_loader' module that no longer exists (it moved to
+        # scripts.plugin_loader), so it never fires. leapp_functions.data_sources
+        # is imported only by artifacts, so without this it is missing from the
+        # frozen build and every artifact importing it dies at load.
+        *collect_submodules('leapp_functions'),
+        # Stdlib that only artifacts import; PyInstaller prunes stdlib it cannot
+        # see used, so these are absent from the frozen build without this list
+        # (the local frozen smoke run died on xml.etree).
+        'bz2',
+        'gzip',
+        'tarfile',
+        'xml.etree.ElementTree',
+    ],
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],


### PR DESCRIPTION
Pre-flight for the test_builds workflow port, same frozen-build defect class as ALEAPP #1097 and RLEAPP #407: artifacts are bundled as data files and imported from disk at runtime, so PyInstaller's import-graph analysis never sees what they import, and the existing hook-plugin_loader.py never fires (it targets a bare plugin_loader module; the loader moved to scripts.plugin_loader). Every VLEAPP spec shipped an empty hiddenimports list.

Two gaps, found by enumeration plus an actual local frozen run:

- the leapp_functions.data_sources modules that only artifacts import
- stdlib that only artifacts import: bz2, gzip, tarfile, xml.etree.ElementTree. PyInstaller prunes stdlib it cannot see used; the first local frozen smoke run crashed on xml.etree in dipoAudio.py, which is what surfaced this second class.

bs4, pytz and simplekml were already safe: ilapfuncs imports them at module level, so they ride the main import graph.

Verified locally: built vleapp_macOS.spec on Python 3.14 with these changes and ran the frozen CLI end to end (--help plus an empty-input run): 74 modules loaded, exit 0, no import errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)