### PR TITLE
Add a check for local filesystem paths in report output

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -50,6 +50,15 @@ jobs:
         if: steps.changed-files-py.outputs.any_changed == 'true'
         run: python admin/scripts/check_html_safety.py
 
+      # The seeker stages evidence under <report folder>/data, so every files_found entry
+      # is an absolute path on the examiner's machine. artifact_processor normalizes only
+      # the third element of the return tuple; a path put in a data row or handed to
+      # write_artifact_data_table is published verbatim. The column is never empty and the
+      # row count is always right, so nothing else catches it. See the script's docstring.
+      - name: Guard report output against local filesystem paths
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python admin/scripts/check_report_local_paths.py
+
       # Fails only on warnings this pull request introduces. vleapp.py and
       # vleappGUI.py carry pre-existing warnings that are structural rather than
       # fixable -- wildcard imports are how those modules are put together -- so

--- a/admin/scripts/check_report_local_paths.py
+++ b/admin/scripts/check_report_local_paths.py
@@ -1,0 +1,348 @@
+"""Guard report output against the examiner's own filesystem paths.
+
+Every seeker copies a matched evidence file into a staging directory before an artifact
+sees it:
+
+    <report folder>/data/<evidence relative path>
+
+so every entry in `files_found` is an ABSOLUTE path on the machine running the tool. It
+carries the account name, the case folder and the report directory layout. None of that
+belongs in a report that gets handed to someone else.
+
+`artifact_processor` normalizes exactly one thing: the third element of an artifact's
+return tuple. It splits that on newlines and passes each piece through
+`Context.get_relative_path`, which strips the staging prefix.
+
+    return data_headers, data_list, source_path      # <- normalized for you
+
+NOTHING ELSE IS NORMALIZED. A value placed in a data row is written verbatim to the HTML
+report, the TSV export, the timeline, the KML and the LAVA database, so a staged path put
+in a column is published five ways and persisted in two of them. The same applies to a
+path handed straight to `report.write_artifact_data_table`, whose third argument becomes
+the page's "located at" line with no normalization at all.
+
+The fix is always to reduce the value where it enters the row, never afterwards:
+
+    data_list.append((ts, msg, context.get_relative_path(file_found)))   # correct
+    data_list.append((ts, msg, file_found))                             # WRONG
+
+`os.path.basename(...)` and `Path(...).name` are equally accepted when a bare filename is
+what the column is for.
+
+Two things make this defect invisible without a check like this one. The column is never
+empty and the row count is always right, so no snapshot, row-count assertion or lint rule
+notices. And `Context.get_relative_path` FAILS OPEN: given a path that does not carry the
+staging prefix it returns the string unchanged rather than raising. The committed test
+harness never sets `Context._data_folder`, so in that harness the function is a no-op and
+a leaking artifact and a correct one record identical output. That is why this check reads
+the source rather than a recorded baseline.
+
+Scope: functions decorated with `artifact_processor` or `artifact_processor_streaming`,
+which are the ones whose return value reaches a report. A helper that carries a full path
+between functions is fine and is not reported; what matters is the value at the row.
+
+Found by auditing all five cores in 2026-08: 38 sites across 31 artifacts, including all
+16 Chromium artifacts in iLEAPP's chrome.py (which build their own per-browser reports and
+so bypass the wrapper) and a 1,085-row LAVA column in appGrouplisting.
+
+Usage:
+  check_report_local_paths.py [--root REPO_ROOT] [--verbose]
+
+Exits 1 when anything is found, 0 otherwise.
+
+Allowlist
+---------
+A genuine exception goes in ALLOWLIST below, keyed "<module>.py:<function>:<expression>",
+with a reason. Keep it short: a value that legitimately belongs in a column is nearly
+always a filename or a device-internal path, and neither trips this check.
+"""
+
+import argparse
+import ast
+import os
+import sys
+
+# "<module>.py:<function>:<expression>" -> why this one is not a leak.
+ALLOWLIST = {}
+
+DECORATORS = {'artifact_processor', 'artifact_processor_streaming'}
+STREAMING_DECORATOR = 'artifact_processor_streaming'
+
+# Names that hold a full staged path when they come from the framework.
+TAINT_PARAM_NAMES = {'files_found', 'file_found'}
+
+# Calls returning a full staged path. Attribute calls are only taint sources when the
+# receiver is the framework object, so `re.search(...)` and `message.walk()` are not
+# mistaken for `seeker.search(...)` and `os.walk(...)`.
+TAINT_PLAIN_CALLS = {'get_file_path'}
+TAINT_ATTR_CALLS = {
+    'search': {'seeker', 'self'},
+    'walk': {'os'},
+    'get_files_found': {'context', 'Context'},
+    'get_report_folder': {'context', 'Context'},
+    'get_source_file_path': {'context', 'Context'},
+}
+
+# Wrappers that return their argument unchanged for our purposes, whether written bare
+# or through a module (`Path(x)`, `pathlib.Path(x)`, `os.path.abspath(x)`).
+PASSTHROUGH_CALLS = {
+    'str', 'Path', 'PurePath', 'PurePosixPath', 'PureWindowsPath',
+    'sorted', 'set', 'list', 'tuple', 'abspath', 'realpath', 'normpath',
+}
+
+# Calls and attributes that reduce a full path to something publishable.
+SANITIZERS = {
+    'basename', 'get_relative_path', 'relative_to', 'sanitize_report_name',
+    'safe_local_path', 'check_in_media',
+}
+# Attributes that yield a NAME or a component rather than a path. `parents` is
+# deliberately absent: `Path(p).parents[1]` is a full directory path and has leaked.
+SAFE_ATTRS = {'name', 'stem', 'suffix', 'parts'}
+# Methods whose result is a piece of the string, not the whole path.
+SAFE_METHODS = {'split', 'rsplit', 'partition', 'rpartition', 'replace', 'strip'}
+
+ROW_VARS = ('data_list', 'data_rows', 'rows', 'records', 'entries')
+
+STANDARD_NOTE = (
+    'Reduce the value where it enters the row: context.get_relative_path(x) for a path, '
+    'or os.path.basename(x) when the column is a filename. The third element of the '
+    'return tuple is normalized for you and does not need this.'
+)
+
+
+def decorator_names(node):
+    names = []
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name):
+            names.append(dec.id)
+        elif isinstance(dec, ast.Attribute):
+            names.append(dec.attr)
+        elif isinstance(dec, ast.Call):
+            func = dec.func
+            names.append(func.id if isinstance(func, ast.Name) else getattr(func, 'attr', ''))
+    return names
+
+
+def receiver_name(node):
+    """The left-hand name of an attribute access, or ''."""
+    value = node.value
+    if isinstance(value, ast.Name):
+        return value.id
+    if isinstance(value, ast.Attribute):
+        return value.attr
+    return ''
+
+
+class FunctionScan:
+    """Taint over one artifact function."""
+
+    def __init__(self, func):
+        self.func = func
+        self.tainted = self._collect()
+
+    def is_tainted(self, node):
+        if node is None:
+            return False
+        if isinstance(node, ast.Name):
+            return node.id in self.tainted
+        if isinstance(node, ast.Subscript):
+            # x[0] of a tainted container is still a path; a component of .parts is not.
+            if isinstance(node.value, ast.Attribute) and node.value.attr in SAFE_ATTRS:
+                return False
+            return self.is_tainted(node.value)
+        if isinstance(node, ast.Attribute):
+            if node.attr in SANITIZERS or node.attr in SAFE_ATTRS:
+                return False
+            return self.is_tainted(node.value)
+        if isinstance(node, ast.Call):
+            return self._call_tainted(node)
+        if isinstance(node, ast.JoinedStr):
+            return any(self.is_tainted(part.value) for part in node.values
+                       if isinstance(part, ast.FormattedValue))
+        if isinstance(node, ast.BinOp):
+            return self.is_tainted(node.left) or self.is_tainted(node.right)
+        if isinstance(node, (ast.ListComp, ast.SetComp, ast.GeneratorExp)):
+            return any(self.is_tainted(gen.iter) for gen in node.generators)
+        return False
+
+    @staticmethod
+    def _sanitizes(node):
+        """Whether this expression is an explicit reduction of a path."""
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', '')
+            return name in SANITIZERS or name in SAFE_METHODS
+        if isinstance(node, ast.Attribute):
+            return node.attr in SAFE_ATTRS
+        return False
+
+    def _call_tainted(self, node):
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, 'id', '')
+        if name in SANITIZERS or name in SAFE_METHODS:
+            return False
+        # Wrappers that hand back whatever they were given. Reached as a bare name
+        # (`Path(x)`) or through a module (`pathlib.Path(x)`, `os.path.abspath(x)`).
+        if name in PASSTHROUGH_CALLS:
+            return any(self.is_tainted(a) for a in node.args)
+        if isinstance(func, ast.Attribute):
+            if name in TAINT_ATTR_CALLS and receiver_name(func) in TAINT_ATTR_CALLS[name]:
+                return True
+            if name == 'join':
+                # os.path.join(tainted, ...) is still a full path.
+                return any(self.is_tainted(a) for a in node.args)
+            return False
+        return name in TAINT_PLAIN_CALLS
+
+    def _collect(self):
+        tainted = {a.arg for a in self.func.args.args if a.arg in TAINT_PARAM_NAMES}
+        for _ in range(8):
+            before = len(tainted)
+            self.tainted = tainted
+            for node in ast.walk(self.func):
+                if isinstance(node, ast.For):
+                    if self.is_tainted(node.iter) or (
+                            isinstance(node.iter, ast.Name)
+                            and node.iter.id in TAINT_PARAM_NAMES):
+                        if isinstance(node.target, ast.Name):
+                            tainted.add(node.target.id)
+                elif isinstance(node, ast.Assign):
+                    if self.is_tainted(node.value):
+                        for target in node.targets:
+                            if isinstance(target, ast.Name):
+                                tainted.add(target.id)
+                    elif self._sanitizes(node.value):
+                        # Only an explicit reduction clears taint. A bare
+                        # `db_files = []` must not, or it races the later
+                        # `db_files.append(file_found)` on every pass and the
+                        # loop over that list is never seen as tainted.
+                        for target in node.targets:
+                            if isinstance(target, ast.Name):
+                                tainted.discard(target.id)
+                elif isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                    call = node.value
+                    # A list built by appending a tainted value is itself tainted, so
+                    # iterating it later yields tainted names.
+                    if (isinstance(call.func, ast.Attribute)
+                            and call.func.attr in ('append', 'add', 'extend')
+                            and isinstance(call.func.value, ast.Name)
+                            and call.args and self.is_tainted(call.args[0])):
+                        tainted.add(call.func.value.id)
+            if len(tainted) == before:
+                break
+        self.tainted = tainted
+        return tainted
+
+
+def scan_function(func, module, streaming):
+    """Violations for one decorated artifact function."""
+    scan = FunctionScan(func)
+    if not scan.tainted:
+        return []
+    found = []
+
+    def record(line, kind, expr, column):
+        key = f'{module}:{func.name}:{expr}'
+        if key in ALLOWLIST:
+            return
+        found.append((line, kind, expr, column))
+
+    for node in ast.walk(func):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == 'write_artifact_data_table' and len(node.args) >= 3):
+            if scan.is_tainted(node.args[2]):
+                record(node.lineno, 'located-at', ast.unparse(node.args[2]), None)
+
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ('append', 'extend') and node.args):
+            target = node.func.value
+            name = target.id if isinstance(target, ast.Name) else ''
+            if not any(hint in name.lower() for hint in ROW_VARS):
+                continue
+            arg = node.args[0]
+            elements = arg.elts if isinstance(arg, (ast.Tuple, ast.List)) else [arg]
+            for index, element in enumerate(elements):
+                if scan.is_tainted(element):
+                    record(node.lineno, 'row-value', ast.unparse(element), index)
+
+        if streaming and isinstance(node, ast.Expr) and isinstance(node.value, ast.Yield):
+            value = node.value.value
+            if isinstance(value, (ast.Tuple, ast.List)):
+                for index, element in enumerate(value.elts):
+                    if scan.is_tainted(element):
+                        record(node.lineno, 'yielded-row', ast.unparse(element), index)
+    return found
+
+
+def scan_module(path):
+    module = os.path.basename(path)
+    try:
+        with open(path, encoding='utf-8', errors='replace') as handle:
+            tree = ast.parse(handle.read())
+    except SyntaxError as err:
+        return [], f'{module}: could not parse ({err})'
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        decorators = decorator_names(node)
+        if not DECORATORS.intersection(decorators):
+            continue
+        streaming = STREAMING_DECORATOR in decorators
+        for line, kind, expr, column in scan_function(node, module, streaming):
+            violations.append((module, node.name, line, kind, expr, column))
+    return violations, None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--root', default=None, help='repository root')
+    parser.add_argument('--verbose', action='store_true',
+                        help='list every artifact function checked')
+    args = parser.parse_args()
+
+    root = args.root or os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    artifacts = os.path.join(root, 'scripts', 'artifacts')
+    if not os.path.isdir(artifacts):
+        print(f'No scripts/artifacts under {root}', file=sys.stderr)
+        return 2
+
+    violations, unreadable, modules = [], [], 0
+    for name in sorted(os.listdir(artifacts)):
+        if not name.endswith('.py'):
+            continue
+        modules += 1
+        found, problem = scan_module(os.path.join(artifacts, name))
+        violations.extend(found)
+        if problem:
+            unreadable.append(problem)
+
+    if args.verbose:
+        for module, func, line, kind, expr, column in violations:
+            print(f'{module}:{line} {func} {kind} {expr}')
+
+    if violations:
+        print(f'Local filesystem paths reaching report output ({len(violations)}):')
+        for module, func, line, kind, expr, column in violations:
+            where = f'column {column}' if column is not None else '"located at" line'
+            print(f'  {module}:{line}  {func}()  {kind}  {where}')
+            print(f'      {expr}')
+        print()
+        print(STANDARD_NOTE)
+        if ALLOWLIST:
+            print(f'{len(ALLOWLIST)} allowlisted expression(s) were not reported.')
+        return 1
+
+    summary = f'Checked {modules} artifact module(s): no local paths reach report output.'
+    if unreadable:
+        summary += f' {len(unreadable)} module(s) NOT checked.'
+    print(summary)
+    for problem in unreadable:
+        print(f'  {problem}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/test/scripts/test_check_report_local_paths.py
+++ b/admin/test/scripts/test_check_report_local_paths.py
@@ -1,0 +1,217 @@
+"""Prove the local-path checker still detects the defects it exists to detect.
+
+check_report_local_paths.py reads artifact source and reports staged paths that reach
+report output. It is itself a script and can rot. Two of its own rules were wrong before
+they were right in the session that introduced it, and only a run against known input
+caught either:
+
+  * `pathlib.Path(file_found)` was not recognised as passing taint through, because the
+    passthrough set was consulted only for bare `Path(...)` and not for an attribute call.
+    That hid a real leak in appGrouplisting.
+  * clearing taint on any untainted assignment made `db_files = []` race the later
+    `db_files.append(file_found)` on every pass of the fixed point, so the loop over that
+    list was never seen as tainted. That hid a real leak in ZangiMessenger.
+
+Both shapes are pinned below, so an edit that reintroduces either fails here instead of
+shipping a checker that quietly passes everything.
+
+The false-negative cases matter as much as the positives: a checker wired into CI that
+flags correct code gets disabled, so the shapes that must stay silent are pinned too.
+"""
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import textwrap
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_MODULE_PATH = REPO_ROOT / 'admin' / 'scripts' / 'check_report_local_paths.py'
+
+# admin/scripts is not a package, so load the module from its path.
+_spec = importlib.util.spec_from_file_location('check_report_local_paths', _MODULE_PATH)
+crlp = importlib.util.module_from_spec(_spec)
+sys.modules['check_report_local_paths'] = crlp
+_spec.loader.exec_module(crlp)
+
+
+def findings_for(source):
+    """The violations the checker reports for one module's source text."""
+    with tempfile.TemporaryDirectory() as folder:
+        path = pathlib.Path(folder) / 'sample.py'
+        path.write_text(textwrap.dedent(source), encoding='utf-8')
+        violations, problem = crlp.scan_module(str(path))
+    if problem:
+        raise AssertionError(problem)
+    return violations
+
+
+class RowValues(unittest.TestCase):
+    def test_flags_a_staged_path_placed_in_a_row(self):
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append(('a', file_found))
+                return (), data_list, ''
+        ''')
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][3], 'row-value')
+
+    def test_get_relative_path_is_accepted(self):
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append(('a', context.get_relative_path(file_found)))
+                return (), data_list, ''
+        '''), [])
+
+    def test_basename_is_accepted(self):
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append(('a', os.path.basename(file_found)))
+                return (), data_list, ''
+        '''), [])
+
+    def test_the_returned_source_path_is_not_reported(self):
+        """The wrapper normalizes the third element, so it is not a leak."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                source_path = ''
+                for file_found in context.get_files_found():
+                    source_path = file_found
+                    data_list.append(('a', 'b'))
+                return (), data_list, source_path
+        '''), [])
+
+
+class ShapesThatOnceHidALeak(unittest.TestCase):
+    def test_pathlib_path_passes_taint_through(self):
+        """appGrouplisting: fileloc = str(pathlib.Path(file_found).parents[1])."""
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    p = pathlib.Path(file_found)
+                    data_list.append(('a', str(p.parents[1])))
+                return (), data_list, ''
+        ''')
+        self.assertEqual(len(found), 1, 'pathlib.Path must pass taint through')
+
+    def test_a_list_built_by_appending_stays_tainted(self):
+        """ZangiMessenger: db_files = [] then db_files.append(file_found)."""
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                db_files = []
+                for file_found in context.get_files_found():
+                    db_files.append(file_found)
+                for main_db in db_files:
+                    data_list.append(('a', main_db))
+                return (), data_list, ''
+        ''')
+        self.assertEqual(len(found), 1, 'an initializer must not clear container taint')
+
+
+class LocatedAt(unittest.TestCase):
+    def test_flags_a_staged_path_handed_to_the_report_writer(self):
+        found = findings_for('''
+            @artifact_processor
+            def demo(context):
+                for file_found in context.get_files_found():
+                    report.write_artifact_data_table(headers, rows, file_found)
+                return (), [], ''
+        ''')
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0][3], 'located-at')
+
+
+class MustStaySilent(unittest.TestCase):
+    def test_an_undecorated_helper_is_not_checked(self):
+        """A helper carrying a full path between functions is normal and correct."""
+        self.assertEqual(findings_for('''
+            def _helper(files_found):
+                rows = []
+                for file_found in files_found:
+                    rows.append(('a', file_found))
+                return rows
+        '''), [])
+
+    def test_a_regex_match_is_not_a_path(self):
+        """protonVPN: re.search(...) must not be read as seeker.search(...)."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    hostname = re.search(r'node.+', line)
+                    data_list.append((hostname[0], 'b'))
+                return (), data_list, ''
+        '''), [])
+
+    def test_a_path_component_is_not_a_path(self):
+        """installedapps: Path(file_found).parts[-4] is the Android user id."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    user = pathlib.Path(file_found).parts[-4]
+                    data_list.append((user, 'b'))
+                return (), data_list, ''
+        '''), [])
+
+    def test_an_email_message_walk_is_not_os_walk(self):
+        """mailprotect: message.walk() yields MIME parts, not filesystem paths."""
+        self.assertEqual(findings_for('''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    names = ', '.join(p.get_filename() for p in message.walk())
+                    data_list.append((names, 'b'))
+                return (), data_list, ''
+        '''), [])
+
+
+class Allowlist(unittest.TestCase):
+    def test_an_allowlisted_expression_is_not_reported(self):
+        source = '''
+            @artifact_processor
+            def demo(context):
+                data_list = []
+                for file_found in context.get_files_found():
+                    data_list.append(('a', file_found))
+                return (), data_list, ''
+        '''
+        self.assertEqual(len(findings_for(source)), 1)
+        crlp.ALLOWLIST['sample.py:demo:file_found'] = 'pinned by this test'
+        try:
+            self.assertEqual(findings_for(source), [])
+        finally:
+            del crlp.ALLOWLIST['sample.py:demo:file_found']
+
+
+class TheRepoItself(unittest.TestCase):
+    def test_no_artifact_in_this_repo_leaks_a_local_path(self):
+        self.assertEqual(crlp.main.__module__, 'check_report_local_paths')
+        artifacts = REPO_ROOT / 'scripts' / 'artifacts'
+        offenders = []
+        for module in sorted(artifacts.glob('*.py')):
+            violations, _ = crlp.scan_module(str(module))
+            offenders.extend(violations)
+        self.assertEqual(offenders, [], f'{len(offenders)} local path(s) reach report output')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The seeker stages evidence under the report folder, so a path taken from files_found is absolute on the machine that ran the tool. artifact_processor normalizes only the third element of the return tuple; a path placed in a data row or handed to the report writer is published as-is.

Nothing else catches it: the column is never empty and the row count is always right. The check reads artifact source and runs in the lint job.

No artifact here is affected. Added for parity with the iLEAPP and ALEAPP copies, which are byte-identical.