### PR TITLE
Add Ford Sync G4 and BMW connected device artifacts

### DIFF
--- a/scripts/artifacts/bmw_connected_devices.py
+++ b/scripts/artifacts/bmw_connected_devices.py
@@ -1,0 +1,160 @@
+__artifacts_v2__ = {
+    "bmw_connected_apple_devices": {
+        "name": "Connected Apple Devices",
+        "description": "Apple devices the head unit indexed over the iAP2 accessory "
+                       "protocol, with the identifier the unit used to name each store and "
+                       "the media libraries it recorded for that device.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "BMW Vehicles",
+        "notes": "The unit keeps one store per device under a directory whose name carries "
+                 "the identifier it indexed the device by, either a Bluetooth MAC or a "
+                 "device serial. That identifier is parsed from the path and reported "
+                 "alongside the device UDID held in the iap2_library table, so the two can "
+                 "be compared rather than one being inferred from the other. Only backup "
+                 "copies of these stores were present on the tested image, so what is "
+                 "reported is the state when the unit wrote that backup, which is not "
+                 "necessarily the state at acquisition. A row means the unit indexed a "
+                 "device's media library; it does not establish who was in the vehicle, and "
+                 "a library named for a streaming service is the service rather than "
+                 "content the device carried.",
+        "paths": ('*/iap2_*.db.backup',),
+        "sample_data": {
+            "bmw_mgu_2024_pers_logical": "2024 BMW MGU | 12 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "smartphone",
+    },
+    "bmw_connected_device_media": {
+        "name": "Connected Device Media",
+        "description": "Media items the head unit indexed from connected Apple devices, "
+                       "with title, artist, album, genre and duration as the unit recorded "
+                       "them.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "BMW Vehicles",
+        "notes": "From iap2_media_item joined to the artist, album, album artist, genre and "
+                 "composer tables in the same store. Playback duration is reported as "
+                 "stored because nothing available here establishes its units. The type and "
+                 "rating columns are undocumented integers and are also reported as stored. "
+                 "These rows are an index the unit built of a connected device's library: "
+                 "they record what was available to play, not what was played, and the "
+                 "store carries no play count and no last played time. The identifier "
+                 "columns carry the value from the store's directory name so a row can be "
+                 "attributed to the device it came from.",
+        "paths": ('*/iap2_*.db.backup',),
+        "sample_data": {
+            "bmw_mgu_2024_pers_logical": "2024 BMW MGU | 220 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "music",
+    },
+}
+
+import os
+import re
+import sqlite3
+
+from scripts.ilapfuncs import artifact_processor, open_sqlite_db_readonly
+
+# The store directory names the device: iap2_[btmac:..] or iap2_[serial:..].
+# The seeker cannot stage a colon on every filesystem and rewrites it to an
+# underscore, so accept either separator rather than the archive spelling only.
+_DEVICE_KEY = re.compile(r'iap2_\[(btmac|serial)[:_]([^\]]+)\]')
+
+
+def _device_from_path(path):
+    """The identifier kind and value the unit named this store by."""
+    match = _DEVICE_KEY.search(os.path.basename(path))
+    if not match:
+        return '', ''
+    return match.group(1), match.group(2)
+
+
+def _iap2_stores(context):
+    """Every iAP2 store the seeker matched."""
+    for file_found in sorted(str(f) for f in context.get_files_found()):
+        if os.path.isdir(file_found) or not file_found.endswith('.db.backup'):
+            continue
+        yield file_found
+
+
+@artifact_processor
+def bmw_connected_apple_devices(context):
+    data_list = []
+    source_paths = []
+    for store in _iap2_stores(context):
+        db = open_sqlite_db_readonly(store)
+        if db is None:
+            continue
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT library_id, name, device_udid, library_uid, revision, is_itunes
+                FROM iap2_library
+                ORDER BY library_id
+            ''')
+            rows = cursor.fetchall()
+        except sqlite3.Error:
+            db.close()
+            continue
+        db.close()
+        source_paths.append(store)
+        kind, value = _device_from_path(store)
+        for row in rows:
+            data_list.append((kind, value, row[1], row[2], row[3], row[4], row[5],
+                              row[0], context.get_relative_path(store)))
+
+    data_headers = ('Identifier Type', 'Identifier', 'Library Name', 'Device UDID',
+                    'Library UID', 'Revision (as stored)', 'Is iTunes (as stored)',
+                    'Library ID', 'Source File')
+    return data_headers, data_list, '\n'.join(source_paths)
+
+
+@artifact_processor
+def bmw_connected_device_media(context):
+    data_list = []
+    source_paths = []
+    for store in _iap2_stores(context):
+        db = open_sqlite_db_readonly(store)
+        if db is None:
+            continue
+        cursor = db.cursor()
+        try:
+            cursor.execute('''
+                SELECT m.title, ar.artist, al.album, aa.albumartist, g.genre,
+                       c.composer, m.playback_duration, m.type, m.rating,
+                       m.album_track_number, m.is_compilation, l.name
+                FROM iap2_media_item m
+                LEFT JOIN iap2_artist ar ON ar.artist_id = m.artist_id
+                LEFT JOIN iap2_album al ON al.album_id = m.album_id
+                LEFT JOIN iap2_albumartist aa ON aa.albumartist_id = m.albumartist_id
+                LEFT JOIN iap2_genre g ON g.genre_id = m.genre_id
+                LEFT JOIN iap2_composer c ON c.composer_id = m.composer_id
+                LEFT JOIN iap2_library l ON l.library_id = m.library_id
+                ORDER BY ar.artist, al.album, m.album_track_number
+            ''')
+            rows = cursor.fetchall()
+        except sqlite3.Error:
+            db.close()
+            continue
+        db.close()
+        if not rows:
+            continue
+        source_paths.append(store)
+        kind, value = _device_from_path(store)
+        for row in rows:
+            data_list.append((kind, value) + row
+                             + (context.get_relative_path(store),))
+
+    data_headers = ('Identifier Type', 'Identifier', 'Title', 'Artist', 'Album',
+                    'Album Artist', 'Genre', 'Composer', 'Duration (as stored)',
+                    'Type (as stored)', 'Rating (as stored)', 'Track Number',
+                    'Is Compilation (as stored)', 'Library Name', 'Source File')
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/ford_diagnostics.py
+++ b/scripts/artifacts/ford_diagnostics.py
@@ -1,0 +1,137 @@
+__artifacts_v2__ = {
+    "ford_diag_events": {
+        "name": "Diagnostic Events",
+        "description": "Diagnostic events the head unit recorded, with the subsystem that "
+                       "raised each one and the time it was uploaded where the record "
+                       "carries one.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From events_metadata in diagnostics_slave.sqlite. The uploaded column is "
+                 "declared INTEGER but holds a human readable date string once an event has "
+                 "been uploaded and 0 before that, so both the parsed value and the string "
+                 "as stored are reported. That string carries no timezone, so it is taken as "
+                 "written with no conversion applied. On the tested image 180 of 424 rows "
+                 "carried a date. create_time is NOT reported as a time: its values range "
+                 "from 19 to 238080, it does not track uptime, and nothing available "
+                 "establishes what it counts, so reporting it as a clock would be a guess. "
+                 "event_type, event_severity and status are undocumented integers and are "
+                 "reported as stored. creator_id names the subsystem; it is not an "
+                 "indication of who was in the vehicle.",
+        "paths": ('*/diagnostics/db/diagnostics_slave.sqlite*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 424 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "activity",
+    },
+    "ford_diag_upload_errors": {
+        "name": "Diagnostic Upload Errors",
+        "description": "Failures the head unit recorded while trying to upload diagnostic "
+                       "events, each with a timestamp and the boot count current at the time.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From upload_errors in diagnostics_slave.sqlite. timestamp is a Unix time in "
+                 "seconds. start_time is a separate human readable string with no timezone "
+                 "and is reported as stored. boot_count is the unit's own counter and is "
+                 "useful as a sequence: on the tested image 281 errors spanned boot counts "
+                 "736 to 775 over six days, so the counter advances with power cycles, but "
+                 "what exactly increments it is not established here. error_code is an "
+                 "undocumented integer, reported as stored.",
+        "paths": ('*/diagnostics/db/diagnostics_slave.sqlite*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 281 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "alert-triangle",
+    },
+}
+
+import re
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
+                               get_file_path, open_sqlite_db_readonly)
+
+
+def _parse_ctime_string(value):
+    """A 'Wed Nov 29 06:41:41 2023' style string, or None.
+
+    The device writes no timezone, so the value is taken as written rather than
+    shifted. Single digit days are padded with a second space, which strptime
+    will not accept, so runs of whitespace are collapsed first.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        return datetime.strptime(re.sub(r'\s+', ' ', value.strip()),
+                                 '%a %b %d %H:%M:%S %Y').replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+@artifact_processor
+def ford_diag_events(context):
+    data_list = []
+    source_path = get_file_path(context.get_files_found(), "diagnostics_slave.sqlite")
+    if not source_path:
+        return (), [], ''
+    db = open_sqlite_db_readonly(source_path)
+    if db is None:
+        return (), [], context.get_relative_path(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT uploaded, creator_id, ecu, event_type, event_severity,
+               status, uptime, create_time, geid
+        FROM events_metadata
+        ORDER BY uptime
+    ''')
+    for row in cursor.fetchall():
+        uploaded = row[0]
+        parsed = _parse_ctime_string(uploaded)
+        as_stored = uploaded if isinstance(uploaded, str) else ''
+        data_list.append((parsed, as_stored, row[1], row[2], row[3], row[4],
+                          row[5], row[6], row[7], row[8],
+                          context.get_relative_path(source_path)))
+    db.close()
+
+    data_headers = (('Uploaded', 'datetime'), 'Uploaded (as stored)', 'Creator',
+                    'ECU', 'Event Type (as stored)', 'Severity (as stored)',
+                    'Status (as stored)', 'Uptime (as stored)',
+                    'create_time (as stored)', 'Event ID', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def ford_diag_upload_errors(context):
+    data_list = []
+    source_path = get_file_path(context.get_files_found(), "diagnostics_slave.sqlite")
+    if not source_path:
+        return (), [], ''
+    db = open_sqlite_db_readonly(source_path)
+    if db is None:
+        return (), [], context.get_relative_path(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT timestamp, start_time, boot_count, error_code, error_text,
+               duration_sec, transmitter_id, wakelock, event_id
+        FROM upload_errors
+        ORDER BY timestamp
+    ''')
+    for row in cursor.fetchall():
+        data_list.append((convert_unix_ts_to_utc(row[0]), row[1], row[2], row[3],
+                          row[4], row[5], row[6], row[7], row[8],
+                          context.get_relative_path(source_path)))
+    db.close()
+
+    data_headers = (('Timestamp', 'datetime'), 'Start Time (as stored)', 'Boot Count',
+                    'Error Code (as stored)', 'Error Text', 'Duration (seconds)',
+                    'Transmitter', 'Wakelock', 'Event ID', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/ford_diagnostics.py
+++ b/scripts/artifacts/ford_diagnostics.py
@@ -43,7 +43,9 @@ __artifacts_v2__ = {
                  "and is reported as stored. boot_count is the unit's own counter and is "
                  "useful as a sequence: on the tested image 281 errors spanned boot counts "
                  "736 to 775 over six days, so the counter advances with power cycles, but "
-                 "what exactly increments it is not established here. error_code is an "
+                 "what exactly increments it is not established here. That range falls "
+                 "inside the 677 to 776 window the unit's reset-history.txt records, so the "
+                 "two stores can be read against each other. error_code is an "
                  "undocumented integer, reported as stored.",
         "paths": ('*/diagnostics/db/diagnostics_slave.sqlite*',),
         "sample_data": {
@@ -52,13 +54,42 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "alert-triangle",
     },
+    "ford_diag_identifiers": {
+        "name": "Diagnostic Identifiers",
+        "description": "Identifier values the head unit stored beside its diagnostics "
+                       "configuration, reported as stored.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "Each file holds a single 64 character hexadecimal value on one line, and "
+                 "the file name is the unit's own name for it. A 64 character hex string is "
+                 "the length a SHA-256 digest prints to, but what was hashed is not "
+                 "established here: the VIN in the same folder was tested as a preimage in "
+                 "several spellings and did not match any of the three, so no derivation is "
+                 "asserted and the values are reported as stored. On the tested image the "
+                 "three values were distinct from one another. The VIN itself is covered "
+                 "separately by the artifact reading vin.txt, so these are an independent "
+                 "identity record rather than a restatement of it.",
+        "paths": ('*/diagnostics/*_id.txt',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 3 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "hash",
+    },
 }
 
 import re
 from datetime import datetime, timezone
 
+import os
+
 from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
-                               get_file_path, open_sqlite_db_readonly)
+                               get_file_path, logdevinfo,
+                               open_sqlite_db_readonly)
 
 
 def _parse_ctime_string(value):
@@ -135,3 +166,28 @@ def ford_diag_upload_errors(context):
                     'Error Code (as stored)', 'Error Text', 'Duration (seconds)',
                     'Transmitter', 'Wakelock', 'Event ID', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)
+
+
+@artifact_processor
+def ford_diag_identifiers(context):
+    data_list = []
+    source_paths = []
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        try:
+            with open(file_found, 'r', encoding='utf-8', errors='replace') as handle:
+                value = handle.read(4096).strip()
+        except OSError:
+            continue
+        if not value:
+            continue
+        key = os.path.basename(file_found)
+        source_paths.append(file_found)
+        data_list.append((key, value, len(value),
+                          context.get_relative_path(file_found)))
+        logdevinfo(f"Ford diagnostic identifier {key}: {value}")
+
+    data_headers = ('File', 'Stored Value', 'Length', 'Source File')
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/ford_hmi_localstorage.py
+++ b/scripts/artifacts/ford_hmi_localstorage.py
@@ -1,0 +1,143 @@
+__artifacts_v2__ = {
+    "ford_hmi_localstorage": {
+        "name": "HMI Local Storage",
+        "description": "Values the head unit's HMI applications stored in Chromium Local "
+                       "Storage, with the time each write batch was recorded. Superseded "
+                       "versions of a key are reported alongside the current one.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "The HMI applications are Chromium based and keep their state in Local "
+                 "Storage, which is a LevelDB store. It is read here with the vendored "
+                 "ccl_leveldb reader rather than by scanning the files, because LevelDB "
+                 "table blocks are Snappy compressed and a byte scan cannot see them, "
+                 "cannot recover the key a value belonged to, and cannot tell a live record "
+                 "from a superseded one. Timestamps come from the store's own META records, "
+                 "which hold a Chrome epoch in microseconds, and apply to the write batch "
+                 "rather than to the individual key. Every version of a key is reported, "
+                 "not only the current one, so the same key appears once per batch that "
+                 "wrote it and the Live column says which is current. On the tested image "
+                 "one application held 30 versions of its profile list spanning 2023-05-22 "
+                 "to 2024-03-27, and the values differ between versions. What changed "
+                 "between two versions is left to the examiner rather than diffed here. "
+                 "Values are reported as stored: the setting names are the application's "
+                 "own and their integers are undocumented. A stored value records what was "
+                 "written and when; it does not establish who was in the vehicle.",
+        "paths": ('*/system_handled/Local Storage/leveldb/*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 35 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "database",
+    },
+}
+
+import os
+import struct
+
+from scripts.ccl import ccl_leveldb
+from scripts.ilapfuncs import artifact_processor, convert_unix_ts_to_utc
+
+_META_PREFIX = b'META:'
+# Chromium writes Local Storage values with a one byte encoding marker.
+_UTF16_MARKER = 0
+# Seconds between the Windows/Chrome epoch (1601-01-01) and the Unix epoch.
+_CHROME_EPOCH_OFFSET = 11644473600
+
+
+def _decode_value(raw):
+    """A Local Storage value, decoded by its own leading encoding marker."""
+    if not raw:
+        return ''
+    if raw[0] == _UTF16_MARKER:
+        return raw[1:].decode('utf-16-le', 'replace')
+    return raw[1:].decode('utf-8', 'replace')
+
+
+def _meta_timestamp(raw):
+    """The Chrome timestamp out of a META record's protobuf, or None.
+
+    Field 1 is a varint holding microseconds since 1601-01-01.
+    """
+    if not raw or raw[0] != 0x08:            # field 1, varint
+        return None
+    value = shift = 0
+    for byte in raw[1:]:
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return convert_unix_ts_to_utc(value / 1000000 - _CHROME_EPOCH_OFFSET)
+        shift += 7
+    return None
+
+
+@artifact_processor
+def ford_hmi_localstorage(context):
+    data_list = []
+    source_paths = []
+    # The reader needs the store directory, so collapse the matched files to it.
+    store_dirs = set()
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        store_dirs.add(os.path.dirname(file_found))
+
+    for store_dir in sorted(store_dirs):
+        try:
+            store = ccl_leveldb.RawLevelDb(store_dir)
+            records = list(store.iterate_records_raw())
+        except (OSError, ValueError, struct.error, NotImplementedError):
+            continue
+        source_paths.append(store_dir)
+
+        # META records carry the batch time; a value record belongs to the
+        # newest batch at or below its own sequence number.
+        batches = sorted(
+            (r.seq, _meta_timestamp(r.value))
+            for r in records
+            if r.user_key.startswith(_META_PREFIX) and r.state == ccl_leveldb.KeyState.Live)
+
+        def _batch_time(seq, _batches=batches):
+            stamp = None
+            for batch_seq, batch_time in _batches:
+                if batch_seq <= seq:
+                    stamp = batch_time
+                else:
+                    break
+            return stamp
+
+        # The application directory is not at a fixed depth: the HMI apps sit
+        # directly above system_handled while the packaged apps add a user-data
+        # level. Anchor on the package-style name instead of counting levels.
+        app = ''
+        for part in store_dir.replace('\\', '/').split('/'):
+            if '.' in part and not part.startswith('.'):
+                app = part
+        if not app:
+            app = os.path.basename(os.path.dirname(store_dir))
+        for record in records:
+            key = record.user_key
+            if key.startswith(_META_PREFIX) or not key.startswith(b'_'):
+                continue
+            storage_key, _, script_key = key[1:].partition(b'\x00')
+            if not script_key:
+                continue
+            # The script key carries its own encoding marker, like the value.
+            script_key = _decode_value(script_key)
+            data_list.append((
+                _batch_time(record.seq), app,
+                storage_key.decode('utf-8', 'replace'), script_key,
+                _decode_value(record.value),
+                record.state == ccl_leveldb.KeyState.Live,
+                record.seq, os.path.basename(record.origin_file),
+                context.get_relative_path(store_dir)))
+        store.close()
+
+    data_list.sort(key=lambda row: (row[1], row[3], row[6]))
+    data_headers = (('Batch Written', 'datetime'), 'Application', 'Storage Key',
+                    'Key', 'Value (as stored)', 'Live', 'Sequence',
+                    'Store File', 'Source File')
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/artifacts/ford_installed_software.py
+++ b/scripts/artifacts/ford_installed_software.py
@@ -1,0 +1,57 @@
+__artifacts_v2__ = {
+    "ford_installed_software": {
+        "name": "Installed Software",
+        "description": "Software packages present on the head unit, each with the package "
+                       "identifier, the part number, the display name, the version and the "
+                       "package type the unit recorded.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From the packages table in pacman.db, the unit's own package manager "
+                 "store. The table records no install or update time, so this is an "
+                 "inventory of what is present rather than a history of when it arrived. "
+                 "The type column separates applications from asset packages; on the tested "
+                 "image the asset packages were map regions, so the set of regions present "
+                 "bounds where the built-in navigation could route without a further "
+                 "download. Package identifiers can name the vehicle line the unit was "
+                 "built for. state, format and signature type are reported as stored.",
+        "paths": ('*/alm/pacman/pacman.db*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 30 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "package",
+    },
+}
+
+from scripts.ilapfuncs import (artifact_processor, get_file_path,
+                               open_sqlite_db_readonly)
+
+
+@artifact_processor
+def ford_installed_software(context):
+    data_list = []
+    source_path = get_file_path(context.get_files_found(), "pacman.db")
+    if not source_path:
+        return (), [], ''
+    db = open_sqlite_db_readonly(source_path)
+    if db is None:
+        return (), [], context.get_relative_path(source_path)
+    cursor = db.cursor()
+    cursor.execute('''
+        SELECT name, version, type, package_id, ford_part_number,
+               old_ford_part_number, state, format, signature_type, description
+        FROM packages
+        ORDER BY type, name
+    ''')
+    for row in cursor.fetchall():
+        data_list.append(row + (context.get_relative_path(source_path),))
+    db.close()
+
+    data_headers = ('Name', 'Version', 'Type', 'Package ID', 'Part Number',
+                    'Previous Part Number', 'State (as stored)', 'Format',
+                    'Signature Type (as stored)', 'Description', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/artifacts/ford_nav_settings.py
+++ b/scripts/artifacts/ford_nav_settings.py
@@ -1,0 +1,101 @@
+__artifacts_v2__ = {
+    "ford_nav_user_settings": {
+        "name": "Navigation User Settings",
+        "description": "Settings the built-in navigation application stored against a user "
+                       "profile, each with the value as stored and the time the row was "
+                       "written.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From the user_setting table in the navigation application's "
+                 "data_manager.sqlite. time_stamp is a Unix time in seconds. Setting names "
+                 "are the application's own and most values are undocumented integers, so "
+                 "values are reported as stored and no meaning is assigned to them. The "
+                 "timestamps are worth reading as a group rather than individually: on the "
+                 "tested image most rows shared a timestamp within a few seconds, which is "
+                 "consistent with one bulk write, and a smaller number carried later and "
+                 "well separated times. On the tested image that bulk write fell 22 seconds after the reset recorded in the unit's own reset-reason.txt, which is two stores written by different code paths agreeing on one event. A row records the value in effect and when it was "
+                 "written; it does not establish who changed it, which matters in a vehicle "
+                 "more than one person may use. isBinary marks rows whose value is not "
+                 "plain text, and those are reported as stored without decoding.",
+        "paths": ('*/com.garmin.sync.garmin-app/user-data/data_manager.sqlite*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 50 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+    "ford_nav_global_settings": {
+        "name": "Navigation Global Settings",
+        "description": "Settings the built-in navigation application stored without a user "
+                       "profile, each with the value as stored and the time the row was "
+                       "written.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From the global_setting table in the same store as the user settings, with "
+                 "the same columns except that no profile is recorded. time_stamp is a Unix "
+                 "time in seconds and values are reported as stored. This table is where a "
+                 "setting that applies to the unit rather than to one profile is kept, which "
+                 "on the tested image included the identifier of the profile in use.",
+        "paths": ('*/com.garmin.sync.garmin-app/user-data/data_manager.sqlite*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 44 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+}
+
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
+                               get_file_path, open_sqlite_db_readonly)
+
+
+def _settings_rows(context, query):
+    """Rows from one of the two settings tables, plus the relative source path."""
+    data_list = []
+    source_path = get_file_path(context.get_files_found(), "data_manager.sqlite")
+    if not source_path:
+        return [], ''
+    relative_path = context.get_relative_path(source_path)
+    db = open_sqlite_db_readonly(source_path)
+    if db is None:
+        return [], relative_path
+    cursor = db.cursor()
+    cursor.execute(query)
+    for row in cursor.fetchall():
+        data_list.append((convert_unix_ts_to_utc(row[0]),) + row[1:]
+                         + (relative_path,))
+    db.close()
+    return data_list, relative_path
+
+
+@artifact_processor
+def ford_nav_user_settings(context):
+    data_list, relative_path = _settings_rows(context, '''
+        SELECT time_stamp, setting_id, value, profile_id, isBinary, isDeleted
+        FROM user_setting
+        ORDER BY time_stamp, setting_id
+    ''')
+    data_headers = (('Written', 'datetime'), 'Setting', 'Value (as stored)',
+                    'Profile', 'Is Binary (as stored)', 'Is Deleted (as stored)',
+                    'Source File')
+    return data_headers, data_list, relative_path
+
+
+@artifact_processor
+def ford_nav_global_settings(context):
+    data_list, relative_path = _settings_rows(context, '''
+        SELECT time_stamp, setting_id, value, isBinary, isDeleted
+        FROM global_setting
+        ORDER BY time_stamp, setting_id
+    ''')
+    data_headers = (('Written', 'datetime'), 'Setting', 'Value (as stored)',
+                    'Is Binary (as stored)', 'Is Deleted (as stored)', 'Source File')
+    return data_headers, data_list, relative_path

--- a/scripts/artifacts/ford_power_history.py
+++ b/scripts/artifacts/ford_power_history.py
@@ -32,12 +32,64 @@ __artifacts_v2__ = {
         "output_types": "standard",
         "artifact_icon": "power",
     },
+    "ford_power_last_shutdown": {
+        "name": "Last Shutdown",
+        "description": "The shutdown the head unit recorded most recently, with the boot "
+                       "count, the time, the uptime for that cycle and the initiator and "
+                       "reason it stored.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From last-shutdown.txt, a single record that the unit overwrites, so it "
+                 "reflects one cycle rather than a history. real time is a Unix time in "
+                 "milliseconds and is divided at the call site because the unit is known "
+                 "rather than inferred from magnitude. up-time and total up-time are "
+                 "reported as stored. On the tested image this record sat one cycle ahead of "
+                 "the window in reset-history.txt, which is what shows that history is "
+                 "capped rather than complete.",
+        "paths": ('*/fordlogs/sm/last-shutdown.txt',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 1 row",
+        },
+        "output_types": "standard",
+        "artifact_icon": "power",
+    },
+    "ford_power_reset_reason": {
+        "name": "Last Reset Reason",
+        "description": "The reset the head unit recorded most recently in its own reset "
+                       "reason file, with the boot count, the time, and the initiator and "
+                       "reason it stored.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From reset-reason.txt, a single record the unit overwrites. Same field "
+                 "vocabulary as last-shutdown.txt and the same millisecond epoch, divided at "
+                 "the call site. On the tested image this record named a reset at a much "
+                 "lower boot count than the current one, so the file does not necessarily "
+                 "describe the most recent power cycle. On the tested image its timestamp "
+                 "fell 22 seconds before the first settings write in the navigation "
+                 "application's own store, which is independent corroboration of the same "
+                 "event. Initiator and reason are reported as stored.",
+        "paths": ('*/fordlogs/sm/reset-reason.txt',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 1 row",
+        },
+        "output_types": "standard",
+        "artifact_icon": "rotate-ccw",
+    },
 }
 
 import re
 from datetime import datetime, timezone
 
-from scripts.ilapfuncs import artifact_processor, get_file_path
+from scripts.ilapfuncs import (artifact_processor, convert_unix_ts_to_utc,
+                               get_file_path)
 
 # "2024-03-29 10:11:53.257 boot 776 up-time 073.676 total-up-time 678157"
 _STAMP = re.compile(r'(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)'
@@ -105,3 +157,54 @@ def ford_power_history(context):
                     'Reboot Source (as stored)', 'Up Time (seconds)',
                     'Total Up Time (as stored)', 'Source File')
     return data_headers, data_list, context.get_relative_path(source_path)
+
+
+def _single_record(context, filename):
+    """The one key/value record these single-cycle files hold, or None."""
+    source_path = get_file_path(context.get_files_found(), filename)
+    if not source_path:
+        return None, ''
+    try:
+        with open(source_path, 'r', encoding='utf-8', errors='replace') as handle:
+            text = handle.read()
+    except OSError:
+        return None, context.get_relative_path(source_path)
+    fields = {}
+    for line in text.splitlines():
+        key, sep, value = line.partition(':')
+        if sep:
+            fields[key.strip()] = value.strip()
+    return fields, context.get_relative_path(source_path)
+
+
+def _power_row(fields, relative_path):
+    """One row, shared by last-shutdown.txt and reset-reason.txt."""
+    try:
+        # The unit is known to be milliseconds, so it is divided here rather
+        # than handed to a helper that infers the unit from magnitude.
+        stamp = convert_unix_ts_to_utc(int(fields.get('real time', '')) / 1000)
+    except ValueError:
+        stamp = None
+    return (stamp, fields.get('boot count', ''), fields.get('initiator', ''),
+            fields.get('reason', ''), fields.get('up-time', ''),
+            fields.get('total up-time', ''), relative_path)
+
+
+_POWER_HEADERS = (('Timestamp', 'datetime'), 'Boot Count', 'Initiator', 'Reason',
+                  'Up Time (as stored)', 'Total Up Time (as stored)', 'Source File')
+
+
+@artifact_processor
+def ford_power_last_shutdown(context):
+    fields, relative_path = _single_record(context, "last-shutdown.txt")
+    if not fields:
+        return (), [], relative_path
+    return _POWER_HEADERS, [_power_row(fields, relative_path)], relative_path
+
+
+@artifact_processor
+def ford_power_reset_reason(context):
+    fields, relative_path = _single_record(context, "reset-reason.txt")
+    if not fields:
+        return (), [], relative_path
+    return _POWER_HEADERS, [_power_row(fields, relative_path)], relative_path

--- a/scripts/artifacts/ford_power_history.py
+++ b/scripts/artifacts/ford_power_history.py
@@ -1,0 +1,107 @@
+__artifacts_v2__ = {
+    "ford_power_history": {
+        "name": "Power and Reset History",
+        "description": "Power cycles the head unit recorded, each with the time it shut "
+                       "down, the time it came back up, the boot count, and the wake source "
+                       "and target mode the unit stored for that cycle.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From the Reset Details section of reset-history.txt. The file also opens "
+                 "with a shorter summary table covering the same cycles; the detail blocks "
+                 "are parsed instead because they carry more fields. Neither timestamp "
+                 "records a timezone, so both are taken as written with no conversion "
+                 "applied. Wake source is reported as stored: on the tested image some "
+                 "values are words (WakeupSource_Ignition, WakeupSource_DriverDoorAjar, "
+                 "WakeupSource_PassengerDoorAjar, WakeupSource_DoorUnLocked, "
+                 "WakeupSource_IlluminationActive) and others are bare numbers "
+                 "(WakeupSource_23, _24, _27, _28, _29) that nothing available here "
+                 "documents, so no meaning is assigned to them. A wake source names what the "
+                 "unit recorded as waking it; it does not establish who was present or that "
+                 "the vehicle moved. The history is a fixed window rather than a complete "
+                 "record: the tested image held exactly 100 blocks covering boot counts 677 "
+                 "to 776, while last-shutdown.txt in the same folder recorded boot count 777, "
+                 "so older cycles had already aged out.",
+        "paths": ('*/fordlogs/sm/reset-history.txt',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 100 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "power",
+    },
+}
+
+import re
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, get_file_path
+
+# "2024-03-29 10:11:53.257 boot 776 up-time 073.676 total-up-time 678157"
+_STAMP = re.compile(r'(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)'
+                    r'(?:\s+boot \d+ up-time ([\d.]+) total-up-time (\d+))?')
+_FIELD = re.compile(r'^\s*([A-Za-z][A-Za-z /]*?):\s{2,}(.*?)\s*$')
+
+
+def _parse_stamp(value):
+    """The datetime from a stamped line, or None.
+
+    The device writes no timezone, so the value is taken as written rather
+    than shifted.
+    """
+    match = _STAMP.search(value or '')
+    if not match:
+        return None, '', ''
+    try:
+        parsed = datetime.strptime(match.group(1),
+                                   '%Y-%m-%d %H:%M:%S.%f').replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None, '', ''
+    return parsed, match.group(2) or '', match.group(3) or ''
+
+
+@artifact_processor
+def ford_power_history(context):
+    data_list = []
+    source_path = get_file_path(context.get_files_found(), "reset-history.txt")
+    if not source_path:
+        return (), [], ''
+    try:
+        with open(source_path, 'r', encoding='utf-8', errors='replace') as handle:
+            text = handle.read()
+    except OSError:
+        return (), [], context.get_relative_path(source_path)
+
+    # The summary table comes first, then the per-cycle detail blocks.
+    _, _, details = text.partition('Reset Details')
+    for block in re.split(r'\n(?=boot count:)', details):
+        if not block.strip().startswith('boot count:'):
+            continue
+        fields = {}
+        for line in block.splitlines():
+            match = _FIELD.match(line)
+            if match:
+                fields[match.group(1).strip()] = match.group(2)
+
+        came_up, uptime, total_uptime = _parse_stamp(fields.get('reset end time', ''))
+        went_down, _, _ = _parse_stamp(fields.get('AP shutdown time', ''))
+
+        wake = re.search(r'WakeSource\(([^)]*)\)', fields.get('RebootSourceData', ''))
+        mode = re.search(r'TargetMode_(\w+)', fields.get('PwrMgrPowerLevel', ''))
+
+        data_list.append((came_up, went_down, fields.get('boot count', ''),
+                          wake.group(1).strip() if wake else '',
+                          mode.group(1) if mode else '',
+                          fields.get('reset type', ''), fields.get('reset initiator', ''),
+                          fields.get('reset reason', ''), fields.get('reboot source', ''),
+                          uptime, total_uptime,
+                          context.get_relative_path(source_path)))
+
+    data_headers = (('Powered On', 'datetime'), ('Previous Shutdown', 'datetime'),
+                    'Boot Count', 'Wake Source (as stored)', 'Target Mode (as stored)',
+                    'Reset Type', 'Reset Initiator', 'Reset Reason',
+                    'Reboot Source (as stored)', 'Up Time (seconds)',
+                    'Total Up Time (as stored)', 'Source File')
+    return data_headers, data_list, context.get_relative_path(source_path)

--- a/scripts/ccl/ccl_leveldb.py
+++ b/scripts/ccl/ccl_leveldb.py
@@ -1,0 +1,585 @@
+"""
+Copyright 2020-2022, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# Vendored from CCL Forensics, unmodified apart from this line. Kept in step with
+# the copies in the sibling extractors.
+# pylint: skip-file
+
+import typing
+import struct
+import re
+import os
+import io
+import pathlib
+import dataclasses
+import enum
+from collections import namedtuple
+from types import MappingProxyType
+
+from scripts.ccl import ccl_simplesnappy
+
+__version__ = "0.4"
+__description__ = "A module for reading LevelDB databases"
+__contact__ = "Alex Caithness"
+
+
+def _read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False) -> typing.Optional[typing.Tuple[int, bytes]]:
+    """Read varint from a stream.
+    If the read is successful: returns a tuple of the (unsigned) value and the raw bytes making up that varint,
+    otherwise returns None.
+    Can be switched to limit the varint to 32 bit."""
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    limit = 5 if is_google_32bit else 10
+    while i < limit:
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+def read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False) -> typing.Optional[int]:
+    """Convenience version of _read_le_varint that only returns the value or None"""
+    x = _read_le_varint(stream, is_google_32bit=is_google_32bit)
+    if x is None:
+        return None
+    else:
+        return x[0]
+
+
+def read_length_prefixed_blob(stream: typing.BinaryIO):
+    length = read_le_varint(stream)
+    data = stream.read(length)
+    if len(data) != length:
+        raise ValueError(f"Could not read all data (expected {length}, got {len(data)}")
+    return data
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockHandle:
+    """See: https://github.com/google/leveldb/blob/master/doc/table_format.md
+    A BlockHandle contains an offset and length of a block in an ldb table file"""
+    offset: int
+    length: int
+
+    @classmethod
+    def from_stream(cls, stream: typing.BinaryIO):
+        return cls(read_le_varint(stream), read_le_varint(stream))
+
+    @classmethod
+    def from_bytes(cls, data: bytes):
+        with io.BytesIO(data) as stream:
+            return BlockHandle.from_stream(stream)
+
+
+@dataclasses.dataclass(frozen=True)
+class RawBlockEntry:
+    """Raw key, value for a record in a LDB file Block, along with the offset within the block from which it came from
+    See: https://github.com/google/leveldb/blob/master/doc/table_format.md"""
+    key: bytes
+    value: bytes
+    block_offset: int
+
+
+class FileType(enum.Enum):
+    Ldb = 1
+    Log = 2
+
+
+class KeyState(enum.Enum):
+    Deleted = 0
+    Live = 1
+    Unknown = 2
+
+
+@dataclasses.dataclass(frozen=True)
+class Record:
+    """A record from leveldb; includes details of the origin file, state, etc."""
+
+    key: bytes
+    value: bytes
+    seq: int
+    state: KeyState
+    file_type: FileType
+    origin_file: os.PathLike
+    offset: int
+    was_compressed: bool
+
+    @property
+    def user_key(self):
+        if self.file_type == FileType.Ldb:
+            if len(self.key) < 8:
+                return self.key
+            else:
+                return self.key[0:-8]
+        else:
+            return self.key
+
+
+    @classmethod
+    def ldb_record(cls, key: bytes, value: bytes, origin_file: os.PathLike,
+                   offset: int, was_compressed: bool):
+        seq = (struct.unpack("<Q", key[-8:])[0]) >> 8
+        if len(key) > 8:
+            state = KeyState.Deleted if key[-8] == 0 else KeyState.Live
+        else:
+            state = KeyState.Unknown
+        return cls(key, value, seq, state, FileType.Ldb, origin_file, offset, was_compressed)
+
+    @classmethod
+    def log_record(cls, key: bytes, value: bytes, seq: int, state: KeyState,
+                   origin_file: os.PathLike, offset: int):
+        return cls(key, value, seq, state, FileType.Log, origin_file, offset, False)
+
+
+class Block:
+    """Block from an .lldb (table) file. See: https://github.com/google/leveldb/blob/master/doc/table_format.md"""
+    def __init__(self, raw: bytes, was_compressed: bool, origin: "LdbFile", offset: int):
+        self._raw = raw
+        self.was_compressed = was_compressed
+        self.origin = origin
+        self.offset = offset
+
+        self._restart_array_count, = struct.unpack("<I", self._raw[-4:])
+        self._restart_array_offset = len(self._raw) - (self._restart_array_count + 1) * 4
+
+    def get_restart_offset(self, index) -> int:
+        offset = self._restart_array_offset + (index * 4)
+        return struct.unpack("<i", self._raw[offset: offset + 4])[0]
+
+    def get_first_entry_offset(self) -> int:
+        return self.get_restart_offset(0)
+
+    def __iter__(self) -> typing.Iterable[RawBlockEntry]:
+        offset = self.get_first_entry_offset()
+        with io.BytesIO(self._raw) as buff:
+            buff.seek(offset)
+
+            key = b""
+
+            while buff.tell() < self._restart_array_offset:
+                start_offset = buff.tell()
+                shared_length = read_le_varint(buff, is_google_32bit=True)
+                non_shared_length = read_le_varint(buff, is_google_32bit=True)
+                value_length = read_le_varint(buff, is_google_32bit=True)
+
+                # sense check
+                if offset >= self._restart_array_offset:
+                    raise ValueError("Reading start of entry past the start of restart array")
+                if shared_length > len(key):
+                    raise ValueError("Shared key length is larger than the previous key")
+
+                key = key[:shared_length] + buff.read(non_shared_length)
+                value = buff.read(value_length)
+
+                yield RawBlockEntry(key, value, start_offset)
+
+
+class LdbFile:
+    """A leveldb table (.ldb or .sst) file."""
+    BLOCK_TRAILER_SIZE = 5
+    FOOTER_SIZE = 48
+    MAGIC = 0xdb4775248b80fb57
+
+    def __init__(self, file: pathlib.Path):
+        if not file.exists():
+            raise FileNotFoundError(file)
+
+        self.path = file
+        self.file_no = int(file.stem, 16)
+
+        self._f = file.open("rb")
+        self._f.seek(-LdbFile.FOOTER_SIZE, os.SEEK_END)
+
+        self._meta_index_handle = BlockHandle.from_stream(self._f)
+        self._index_handle = BlockHandle.from_stream(self._f)
+        self._f.seek(-8, os.SEEK_END)
+        magic, = struct.unpack("<Q", self._f.read(8))
+        if magic != LdbFile.MAGIC:
+            raise ValueError(f"Invalid magic number in {file}")
+
+        self._index = self._read_index()
+
+    def _read_block(self, handle: BlockHandle):
+        # block is the size in the blockhandle plus the trailer
+        # the trailer is 5 bytes long.
+        # idx  size  meaning
+        # 0    1     CompressionType (0 = none, 1 = snappy)
+        # 1    4     CRC32
+
+        self._f.seek(handle.offset)
+        raw_block = self._f.read(handle.length)
+        trailer = self._f.read(LdbFile.BLOCK_TRAILER_SIZE)
+
+        if len(raw_block) != handle.length or len(trailer) != LdbFile.BLOCK_TRAILER_SIZE:
+            raise ValueError(f"Could not read all of the block at offset {handle.offset} in file {self.path}")
+
+        is_compressed = trailer[0] != 0
+        if is_compressed:
+            with io.BytesIO(raw_block) as buff:
+                raw_block = ccl_simplesnappy.decompress(buff)
+
+        return Block(raw_block, is_compressed, self, handle.offset)
+
+    def _read_index(self) -> typing.Tuple[typing.Tuple[bytes, BlockHandle], ...]:
+        index_block = self._read_block(self._index_handle)
+        # key is earliest key, value is BlockHandle to that data block
+        return tuple((entry.key, BlockHandle.from_bytes(entry.value))
+                     for entry in index_block)
+
+    def __iter__(self) -> typing.Iterable[Record]:
+        """Iterate Records in this Table file"""
+        for block_key, handle in self._index:
+            block = self._read_block(handle)
+            for entry in block:
+                yield Record.ldb_record(
+                    entry.key, entry.value, self.path,
+                    block.offset if block.was_compressed else block.offset + entry.block_offset,
+                    block.was_compressed)
+
+    def close(self):
+        self._f.close()
+
+
+class LogEntryType(enum.IntEnum):
+    Zero = 0
+    Full = 1
+    First = 2
+    Middle = 3
+    Last = 4
+
+
+class LogFile:
+    """A levelDb log (.log) file"""
+    LOG_ENTRY_HEADER_SIZE = 7
+    LOG_BLOCK_SIZE = 32768
+
+    def __init__(self, file: pathlib.Path):
+        if not file.exists():
+            raise FileNotFoundError(file)
+
+        self.path = file
+        self.file_no = int(file.stem, 16)
+
+        self._f = file.open("rb")
+
+    def _get_raw_blocks(self) -> typing.Iterable[bytes]:
+        self._f.seek(0)
+
+        while chunk := self._f.read(LogFile.LOG_BLOCK_SIZE):
+            yield chunk
+
+    def _get_batches(self) -> typing.Iterable[typing.Tuple[int, bytes]]:
+        in_record = False
+        start_block_offset = 0
+        block = b""
+        for idx, chunk_ in enumerate(self._get_raw_blocks()):
+            with io.BytesIO(chunk_) as buff:
+                while buff.tell() < LogFile.LOG_BLOCK_SIZE - 6:
+                    header = buff.read(7)
+                    if len(header) < 7:
+                        break
+                    crc, length, block_type = struct.unpack("<IHB", header)
+
+                    if block_type == LogEntryType.Full:
+                        if in_record:
+                            raise ValueError(f"Full block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        in_record = False
+                        yield idx * LogFile.LOG_BLOCK_SIZE + buff.tell(), buff.read(length)
+                    elif block_type == LogEntryType.First:
+                        if in_record:
+                            raise ValueError(f"First block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        start_block_offset = idx * LogFile.LOG_BLOCK_SIZE + buff.tell()
+                        block = buff.read(length)
+                        in_record = True
+                    elif block_type == LogEntryType.Middle:
+                        if not in_record:
+                            raise ValueError(f"Middle block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                    elif block_type == LogEntryType.Last:
+                        if not in_record:
+                            raise ValueError(f"Last block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                        in_record = False
+                        yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block
+                    else:
+                        raise ValueError()  # Cannot happen
+
+    def __iter__(self) -> typing.Iterable[Record]:
+        """Iterate Records in this Log file"""
+        for batch_offset, batch in self._get_batches():
+            # as per write_batch and write_batch_internal
+            # offset       length      description
+            # 0            8           (u?)int64 Sequence number
+            # 8            4           (u?)int32 Count - the log batch can contain multple entries
+            #
+            #         Then Count * the following:
+            #
+            # 12           1           ValueType (KeyState as far as this library is concerned)
+            # 13           1-4         VarInt32 length of key
+            # ...          ...         Key data
+            # ...          1-4         VarInt32 length of value
+            # ...          ...         Value data
+
+            with io.BytesIO(batch) as buff:  # it's just easier this way
+                header = buff.read(12)
+                seq, count = struct.unpack("<QI", header)
+
+                for i in range(count):
+                    start_offset = batch_offset + buff.tell()
+                    state = KeyState(buff.read(1)[0])
+                    key_length = read_le_varint(buff, is_google_32bit=True)
+                    key = buff.read(key_length)
+                    # print(key)
+                    if state != KeyState.Deleted:
+                        value_length = read_le_varint(buff, is_google_32bit=True)
+                        value = buff.read(value_length)
+                    else:
+                        value = b""
+
+                    yield Record.log_record(key, value, seq + i, state, self.path, start_offset)
+
+    def close(self):
+        self._f.close()
+
+
+class VersionEditTag(enum.IntEnum):
+    """
+    See: https://github.com/google/leveldb/blob/master/db/version_edit.cc
+    """
+    Comparator = 1,
+    LogNumber = 2,
+    NextFileNumber = 3,
+    LastSequence = 4,
+    CompactPointer = 5,
+    DeletedFile = 6,
+    NewFile = 7,
+    # 8 was used for large value refs
+    PrevLogNumber = 9
+
+
+@dataclasses.dataclass(frozen=True)
+class VersionEdit:
+    """
+    See:
+    https://github.com/google/leveldb/blob/master/db/version_edit.h
+    https://github.com/google/leveldb/blob/master/db/version_edit.cc
+    """
+    comparator: str = None
+    log_number: int = None
+    prev_log_number: int = None
+    last_sequence: int = None
+    next_file_number: int = None
+    compaction_pointers: typing.Tuple[typing.Any] = tuple()
+    deleted_files: typing.Tuple[typing.Any] = tuple()
+    new_files: typing.Tuple[typing.Any] = tuple()
+
+    @classmethod
+    def from_buffer(cls, buffer: bytes):
+        comparator = None
+        log_number = None
+        prev_log_number = None
+        last_sequence = None
+        next_file_number = None
+        compaction_pointers = []
+        deleted_files = []
+        new_files = []
+
+        compaction_pointer_nt = namedtuple("CompactionPointer", ["level", "pointer"])
+        deleted_file_nt = namedtuple("DeletedFile", ["level", "file_no"])
+        new_file_nt = namedtuple("NewFile", ["level", "file_no", "file_size", "smallest_key", "largest_key"])
+
+        with io.BytesIO(buffer) as b:
+            while b.tell() < len(buffer) - 1:
+                tag = read_le_varint(b, is_google_32bit=True)
+
+                if tag == VersionEditTag.Comparator:
+                    comparator = read_length_prefixed_blob(b).decode("utf-8")
+                elif tag == VersionEditTag.LogNumber:
+                    log_number = read_le_varint(b)
+                elif tag == VersionEditTag.PrevLogNumber:
+                    prev_log_number = read_le_varint(b)
+                elif tag == VersionEditTag.NextFileNumber:
+                    next_file_number = read_le_varint(b)
+                elif tag == VersionEditTag.LastSequence:
+                    last_sequence = read_le_varint(b)
+                elif tag == VersionEditTag.CompactPointer:
+                    level = read_le_varint(b, is_google_32bit=True)
+                    compaction_pointer = read_length_prefixed_blob(b)
+                    compaction_pointers.append(compaction_pointer_nt(level, compaction_pointer))
+                elif tag == VersionEditTag.DeletedFile:
+                    level = read_le_varint(b, is_google_32bit=True)
+                    file_no = read_le_varint(b)
+                    deleted_files.append(deleted_file_nt(level, file_no))
+                elif tag == VersionEditTag.NewFile:
+                    level = read_le_varint(b, is_google_32bit=True)
+                    file_no = read_le_varint(b)
+                    file_size = read_le_varint(b)
+                    smallest = read_length_prefixed_blob(b)
+                    largest = read_length_prefixed_blob(b)
+                    new_files.append(new_file_nt(level, file_no, file_size, smallest, largest))
+
+        return cls(comparator, log_number, prev_log_number, last_sequence, next_file_number, tuple(compaction_pointers),
+            tuple(deleted_files), tuple(new_files))
+
+
+class ManifestFile:
+    """
+    Represents a manifest file which contains database metadata.
+    Manifest files are, at a high level, formatted like a log file in terms of the block and batch format,
+    but the data within the batches follow their own format.
+
+    Main use is to identify the level of files, use `file_to_level` property to look up levels based on file no.
+
+    See:
+    https://github.com/google/leveldb/blob/master/db/version_edit.h
+    https://github.com/google/leveldb/blob/master/db/version_edit.cc
+    """
+
+    MANIFEST_FILENAME_PATTERN = "MANIFEST-([0-9A-F]{6})"
+
+    def __init__(self, path: pathlib.Path):
+        if match := re.match(ManifestFile.MANIFEST_FILENAME_PATTERN, path.name):
+            self.file_no = int(match.group(1))
+        else:
+            raise ValueError("Invalid name for Manifest")
+
+        self._f = path.open("rb")
+        self.path = path
+
+        self.file_to_level = {}
+        for edit in self:
+            if edit.new_files:
+                for nf in edit.new_files:
+                    self.file_to_level[nf.file_no] = nf.level
+
+        self.file_to_level = MappingProxyType(self.file_to_level)
+
+    def _get_raw_blocks(self) -> typing.Iterable[bytes]:
+        self._f.seek(0)
+
+        while chunk := self._f.read(LogFile.LOG_BLOCK_SIZE):
+            yield chunk
+
+    def _get_batches(self) -> typing.Iterable[typing.Tuple[int, bytes]]:
+        in_record = False
+        start_block_offset = 0
+        block = b""
+        for idx, chunk_ in enumerate(self._get_raw_blocks()):
+            with io.BytesIO(chunk_) as buff:
+                while buff.tell() < LogFile.LOG_BLOCK_SIZE - 6:
+                    header = buff.read(7)
+                    if len(header) < 7:
+                        break
+                    crc, length, block_type = struct.unpack("<IHB", header)
+
+                    if block_type == LogEntryType.Full:
+                        if in_record:
+                            raise ValueError(f"Full block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        in_record = False
+                        yield idx * LogFile.LOG_BLOCK_SIZE + buff.tell(), buff.read(length)
+                    elif block_type == LogEntryType.First:
+                        if in_record:
+                            raise ValueError(f"First block whilst still building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        start_block_offset = idx * LogFile.LOG_BLOCK_SIZE + buff.tell()
+                        block = buff.read(length)
+                        in_record = True
+                    elif block_type == LogEntryType.Middle:
+                        if not in_record:
+                            raise ValueError(f"Middle block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                    elif block_type == LogEntryType.Last:
+                        if not in_record:
+                            raise ValueError(f"Last block whilst not building a block at offset "
+                                             f"{idx * LogFile.LOG_BLOCK_SIZE + buff.tell()} in {self.path}")
+                        block += buff.read(length)
+                        in_record = False
+                        yield start_block_offset * LogFile.LOG_BLOCK_SIZE, block
+                    else:
+                        raise ValueError()  # Cannot happen
+
+    def __iter__(self):
+        for batch_offset, batch in self._get_batches():
+            yield VersionEdit.from_buffer(batch)
+
+    def close(self):
+        self._f.close()
+
+
+class RawLevelDb:
+    DATA_FILE_PATTERN = r"[0-9]{6}\.(ldb|log|sst)"
+
+    def __init__(self, in_dir: os.PathLike):
+
+        self._in_dir = pathlib.Path(in_dir)
+        if not self._in_dir.is_dir():
+            raise ValueError("in_dir is not a directory")
+
+        self._files = []
+        latest_manifest = (0, None)
+        for file in self._in_dir.iterdir():
+            if file.is_file() and re.match(RawLevelDb.DATA_FILE_PATTERN, file.name):
+                if file.suffix.lower() == ".log":
+                    self._files.append(LogFile(file))
+                elif file.suffix.lower() == ".ldb" or file.suffix.lower() == ".sst":
+                    self._files.append(LdbFile(file))
+            if file.is_file() and re.match(ManifestFile.MANIFEST_FILENAME_PATTERN, file.name):
+                manifest_no = int(re.match(ManifestFile.MANIFEST_FILENAME_PATTERN, file.name).group(1), 16)
+                if latest_manifest[0] < manifest_no:
+                    latest_manifest = (manifest_no, file)
+
+        self.manifest = ManifestFile(latest_manifest[1]) if latest_manifest[1] is not None else None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @property
+    def in_dir_path(self) -> pathlib.Path:
+        return self._in_dir
+
+    def iterate_records_raw(self, *, reverse=False) -> typing.Iterable[Record]:
+        for file_containing_records in sorted(self._files, reverse=reverse, key=lambda x: x.file_no):
+            yield from file_containing_records
+
+    def close(self):
+        for file in self._files:
+            file.close()
+        if self.manifest:
+            self.manifest.close()

--- a/scripts/ccl/ccl_simplesnappy.py
+++ b/scripts/ccl/ccl_simplesnappy.py
@@ -1,0 +1,208 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# Vendored from CCL Forensics, unmodified apart from this line. Kept in step with
+# the copies in the sibling extractors.
+# pylint: skip-file
+
+import sys
+import struct
+import io
+import typing
+import enum
+
+__version__ = "0.1"
+__description__ = "Pure Python reimplementation of Google's Snappy decompression"
+__contact__ = "Alex Caithness"
+
+
+DEBUG = False
+
+
+def log(msg):
+    if DEBUG:
+        print(msg)
+
+
+class ElementType(enum.IntEnum):
+    """Run type in the compressed snappy data (literal data or offset to backreferenced data_"""
+    Literal = 0
+    CopyOneByte = 1
+    CopyTwoByte = 2
+    CopyFourByte = 3
+
+
+def _read_le_varint(stream: typing.BinaryIO) -> typing.Optional[typing.Tuple[int, bytes]]:
+    """Read varint from a stream.
+    If the read is successful: returns a tuple of the (unsigned) value and the raw bytes making up that varint,
+    otherwise returns None"""
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    while i < 10:  # 64 bit max possible?
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+def read_le_varint(stream: typing.BinaryIO) -> typing.Optional[int]:
+    """Convenience version of _read_le_varint that only returns the value or None"""
+    x = _read_le_varint(stream)
+    if x is None:
+        return None
+    else:
+        return x[0]
+
+
+def read_uint16(stream: typing.BinaryIO) -> int:
+    """Reads a Uint16 from stream"""
+    return struct.unpack("<H", stream.read(2))[0]
+
+
+def read_uint24(stream: typing.BinaryIO) -> int:
+    """Reads a Uint24 from stream"""
+    return struct.unpack("<I", stream.read(3) + b"\x00")[0]
+
+
+def read_uint32(stream: typing.BinaryIO) -> int:
+    """Reads a Uint32 from stream"""
+    return struct.unpack("<I", stream.read(4))[0]
+
+
+def read_byte(stream: typing.BinaryIO) -> typing.Optional[int]:
+    """Reads a single byte from stream (or returns None if EOD is met)"""
+    x = stream.read(1)
+    if x:
+        return x[0]
+
+    return None
+
+
+def decompress(data: typing.BinaryIO) -> bytes:
+    """Decompresses the snappy compressed data stream"""
+    uncompressed_length = read_le_varint(data)
+    log(f"Uncompressed length: {uncompressed_length}")
+
+    out = io.BytesIO()
+
+    while True:
+        start_offset = data.tell()
+        log(f"Reading tag at offset {start_offset}")
+        type_byte = read_byte(data)
+        if type_byte is None:
+            break
+
+        log(f"Type Byte is {type_byte:02x}")
+
+        tag = type_byte & 0x03
+
+        log(f"Element Type is: {ElementType(tag)}")
+
+        if tag == ElementType.Literal:
+            if ((type_byte & 0xFC) >> 2) < 60:  # embedded in tag
+                length = 1 + ((type_byte & 0xFC) >> 2)
+                log(f"Literal length is embedded in type byte and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 60:  # 8 bit
+                length = 1 + read_byte(data)
+                log(f"Literal length is 8bit and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 61:  # 16 bit
+                length = 1 + read_uint16(data)
+                log(f"Literal length is 16bit and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 62:  # 16 bit
+                length = 1 + read_uint24(data)
+                log(f"Literal length is 24bit and is {length}")
+            elif ((type_byte & 0xFC) >> 2) == 63:  # 16 bit
+                length = 1 + read_uint32(data)
+                log(f"Literal length is 32bit and is {length}")
+            else:
+                raise ValueError()  # cannot ever happen
+
+            literal_data = data.read(length)
+            if len(literal_data) < length:
+                raise ValueError("Couldn't read enough literal data")
+
+            out.write(literal_data)
+
+        else:
+            if tag == ElementType.CopyOneByte:
+                length = ((type_byte & 0x1C) >> 2) + 4
+                offset = ((type_byte & 0xE0) << 3) | read_byte(data)
+            elif tag == ElementType.CopyTwoByte:
+                length = 1 + ((type_byte & 0xFC) >> 2)
+                offset = read_uint16(data)
+            elif tag == ElementType.CopyFourByte:
+                length = 1 + ((type_byte & 0xFC) >> 2)
+                offset = read_uint32(data)
+            else:
+                raise ValueError()  # cannot ever happen
+
+            if offset == 0:
+                raise ValueError("Offset cannot be 0")
+
+            actual_offset = out.tell() - offset
+            log(f"Current Outstream Length: {out.tell()}")
+            log(f"Backreference length: {length}")
+            log(f"Backreference relative offset: {offset}")
+            log(f"Backreference absolute offset: {actual_offset}")
+
+            # have to read incrementally because you might have to read data that you've just written
+            # this is probably a really slow way of doing this.
+            # for i in range(length):
+            #     out.write(out.getbuffer()[actual_offset + i: actual_offset + i + 1].tobytes())
+            # new method for doing the same:
+            buffer = out.getbuffer()[actual_offset: actual_offset + length].tobytes()
+            condition = (offset - length) <= 0
+            if condition:
+                buffer = (buffer * length)[:length]
+                # better safe than sorry, this way we're sure to extend it
+                # as much as needed without doing some extra calculations
+            out.write(buffer)
+
+    result = out.getvalue()
+    if uncompressed_length != len(result):
+        raise ValueError("Wrong data length in uncompressed data")
+        # TODO: allow a partial / potentially bad result via a flag in the function call?
+
+    return result
+
+
+def main(path):
+    import pathlib
+    import hashlib
+    f = pathlib.Path(path).open("rb")
+    decompressed = decompress(f)
+    print(decompressed)
+    sha1 = hashlib.sha1()
+    sha1.update(decompressed)
+    print(sha1.hexdigest())
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])


### PR DESCRIPTION
Adds twelve artifacts across two vehicle platforms, plus the LevelDB reader they need.

Ford Sync G4:
- Power and Reset History (reset-history.txt): shutdown time, power-on time, boot count, wake source and target mode per power cycle. Last Shutdown and Last Reset Reason cover the two single-record files beside it.
- Diagnostic Events, Diagnostic Upload Errors and Diagnostic Identifiers.
- Installed Software (pacman.db). The asset packages are map regions.
- Navigation User Settings and Navigation Global Settings (data_manager.sqlite).
- HMI Local Storage: every version of every key the Chromium based HMI apps stored, with the write batch time from the store's own META records.

BMW:
- Connected Apple Devices and Connected Device Media, from the iAP2 stores. Devices are identified by the Bluetooth MAC or serial in the store directory name and by the UDID held inside it.

Adds scripts/ccl with ccl_leveldb and ccl_simplesnappy, matching the copies already carried by the sibling extractors, so Local Storage is read through a real reader rather than scanned. Its output was checked against ccl_chromium_reader 0.3.18 with no differences in keys or values and none in timestamps to the second.

Undocumented integers, wake sources and identifier values are reported as stored. The text sources record no timezone, so those timestamps are taken as written. The reset history holds a fixed window, not a complete record.