### PR TITLE
Add HMI IndexedDB artifacts

### DIFF
--- a/scripts/artifacts/ford_hmi_indexeddb.py
+++ b/scripts/artifacts/ford_hmi_indexeddb.py
@@ -1,0 +1,193 @@
+__artifacts_v2__ = {
+    "ford_hmi_app_state": {
+        "name": "HMI Application State",
+        "description": "State the head unit's HMI applications persisted to IndexedDB, "
+                       "including the valet mode record, the profile and phone as a key "
+                       "record, trailer settings and software update state.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "The HMI applications are Chromium based and persist state to IndexedDB, "
+                 "whose values are V8 serialized rather than plain text. It is read here "
+                 "with the vendored ccl_chromium_indexeddb reader; scanning the raw files "
+                 "cannot see Snappy compressed table blocks, cannot recover the key a value "
+                 "belonged to, and would misread V8 values as JSON. IndexedDB records carry "
+                 "no timestamp of their own, unlike the Local Storage artifact, so no time "
+                 "is reported. Every version of a key is reported, so a key appears once "
+                 "per write and the values can be read as a sequence. The theme store is "
+                 "deliberately not included: it holds display styling. On the tested image "
+                 "the valet record showed the mode off with no PIN set, and the profile "
+                 "record appeared in three different states. Values are reported as stored "
+                 "and no meaning is assigned to the application's own field names.",
+        "paths": ('*/system_handled/IndexedDB/*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 147 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "database",
+    },
+    "ford_vehicle_capabilities": {
+        "name": "Vehicle Capability Values",
+        "description": "The last value the head unit cached for each of its internal HMI "
+                       "topics, which record the equipment and configuration the vehicle "
+                       "reported.",
+        "author": "@AlexisBrignoni, Claude",
+        "version": "0.1",
+        "creation_date": "2026-08-27",
+        "last_update_date": "2026-08-27",
+        "requirements": "none",
+        "category": "Ford Vehicles",
+        "notes": "From the topic map the HMI applications keep in IndexedDB, read with the "
+                 "vendored ccl_chromium_indexeddb reader. Each row is one topic and the "
+                 "last value cached against it, deduplicated across applications because "
+                 "several applications cache the same topic. On the tested image these were "
+                 "overwhelmingly equipment flags, such as whether a camera view or a "
+                 "climate feature is present, rather than a record of use, so this answers "
+                 "what the vehicle was built with rather than what was done in it. One "
+                 "value on the tested image was live telemetry rather than a capability. "
+                 "Topics and values are reported as stored, and the records carry no "
+                 "timestamp, so when a value was cached is not established.",
+        "paths": ('*/system_handled/IndexedDB/*',),
+        "sample_data": {
+            "ford_syncg4_logical": "Ford Sync G4 | 153 rows",
+        },
+        "output_types": "standard",
+        "artifact_icon": "settings",
+    },
+}
+
+import json
+import os
+import pathlib
+
+from scripts.ccl import ccl_chromium_indexeddb
+from scripts.ilapfuncs import artifact_processor
+
+# Styling only, and its records can reference blobs an extraction may not carry.
+_SKIP_DATABASES = {'THEME_PERSIST'}
+_TOPIC_DATABASE = 'MQTT_API_TOPIC_MAP'
+# The topic map also holds the theme worker's own cache entry, whose value is a
+# raw byte run rather than a capability value. It is excluded so the artifact
+# holds only what its description promises.
+_TOPIC_EXCLUDE_PREFIX = 'com.ford.sdk__customStorage'
+# The reader raises a wide range of types on a truncated or blob-backed record.
+_READ_ERRORS = (ValueError, TypeError, KeyError, IndexError, OSError,
+                NotImplementedError, StopIteration, AttributeError)
+
+
+def _store_dirs(context):
+    """Every IndexedDB leveldb directory the seeker matched."""
+    found = set()
+    for file_found in context.get_files_found():
+        file_found = str(file_found)
+        if os.path.isdir(file_found):
+            continue
+        parent = os.path.dirname(file_found)
+        if parent.endswith('.leveldb'):
+            found.add(parent)
+    return sorted(found)
+
+
+def _application(store_dir):
+    """The application directory name, which is not at a fixed depth."""
+    app = ''
+    for part in store_dir.replace('\\', '/').split('/'):
+        if '.' in part and not part.startswith('.') and not part.endswith('.leveldb'):
+            app = part
+    return app or os.path.basename(os.path.dirname(store_dir))
+
+
+def _as_text(value):
+    """A stored value rendered for the report, without interpreting it."""
+    if isinstance(value, (dict, list)):
+        try:
+            return json.dumps(value, default=str, sort_keys=True)
+        except (TypeError, ValueError):
+            return str(value)
+    return '' if value is None else str(value)
+
+
+def _iter_records(store_dir):
+    """Yield (database, object store, key, value) for one store."""
+    try:
+        wrapped = ccl_chromium_indexeddb.WrappedIndexDB(pathlib.Path(store_dir))
+    except _READ_ERRORS:
+        return
+    try:
+        for database_id in wrapped.database_ids:
+            try:
+                database = wrapped[database_id.dbid_no]
+            except _READ_ERRORS:
+                continue
+            if database.name in _SKIP_DATABASES:
+                continue
+            for store_name in database.object_store_names:
+                try:
+                    store = database.get_object_store_by_name(store_name)
+                    records = list(store.iterate_records())
+                except _READ_ERRORS:
+                    # A record whose blob is absent from the extraction ends
+                    # the iteration; report what was read rather than nothing.
+                    continue
+                for record in records:
+                    key = str(record.key)
+                    # the reader renders a key as "<IdbKey value>"
+                    if key.startswith('<IdbKey '):
+                        key = key[len('<IdbKey '):].rstrip('>')
+                    yield database.name, store_name, key, record.value
+    finally:
+        try:
+            wrapped.close()
+        except _READ_ERRORS:
+            pass
+
+
+@artifact_processor
+def ford_hmi_app_state(context):
+    data_list = []
+    source_paths = []
+    for store_dir in _store_dirs(context):
+        app = _application(store_dir)
+        rows = 0
+        for db_name, store_name, key, value in _iter_records(store_dir):
+            if db_name == _TOPIC_DATABASE:
+                continue
+            data_list.append((app, db_name, store_name, key, _as_text(value),
+                              context.get_relative_path(store_dir)))
+            rows += 1
+        if rows:
+            source_paths.append(store_dir)
+
+    data_headers = ('Application', 'Database', 'Object Store', 'Key',
+                    'Value (as stored)', 'Source File')
+    return data_headers, data_list, '\n'.join(source_paths)
+
+
+@artifact_processor
+def ford_vehicle_capabilities(context):
+    seen = {}
+    source_paths = []
+    for store_dir in _store_dirs(context):
+        app = _application(store_dir)
+        rows = 0
+        for db_name, _store_name, key, value in _iter_records(store_dir):
+            if db_name != _TOPIC_DATABASE or key.startswith(_TOPIC_EXCLUDE_PREFIX):
+                continue
+            # several applications cache the same topic; keep one row per topic
+            if isinstance(value, dict) and 'value' in value:
+                stored = _as_text(value.get('value'))
+            else:
+                stored = _as_text(value)
+            seen.setdefault(key, (app, stored, store_dir))
+            rows += 1
+        if rows:
+            source_paths.append(store_dir)
+
+    data_list = [(topic, stored, app, context.get_relative_path(store_dir))
+                 for topic, (app, stored, store_dir) in sorted(seen.items())]
+    data_headers = ('Topic', 'Value (as stored)', 'First Seen In Application',
+                    'Source File')
+    return data_headers, data_list, '\n'.join(source_paths)

--- a/scripts/ccl/ccl_blink_value_deserializer.py
+++ b/scripts/ccl/ccl_blink_value_deserializer.py
@@ -1,0 +1,405 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# Vendored from CCL Forensics. Only the package-relative imports are changed,
+# to match this repo's flat scripts/ccl layout.
+# pylint: skip-file
+
+import sys
+import enum
+import typing
+from dataclasses import dataclass
+
+from scripts.ccl import ccl_v8_value_deserializer
+
+# See: https://chromium.googlesource.com/chromium/src/third_party/+/master/blink/renderer/bindings/core/v8/serialization
+#      https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/bindings/modules/v8/serialization/v8_script_value_serializer_for_modules.cc
+
+
+# WebCoreStrings are read as (length:uint32_t, string:UTF8[length]).
+# RawStrings are read as (length:uint32_t, string:UTF8[length]).
+# RawUCharStrings are read as
+#     (length:uint32_t, string:UChar[length/sizeof(UChar)]).
+# RawFiles are read as
+#     (path:WebCoreString, url:WebCoreStrng, type:WebCoreString).
+# There is a reference table that maps object references (uint32_t) to
+# v8::Values.
+# Tokens marked with (ref) are inserted into the reference table and given the
+# next object reference ID after decoding.
+# All tags except InvalidTag, PaddingTag, ReferenceCountTag, VersionTag,
+# GenerateFreshObjectTag and GenerateFreshArrayTag push their results to the
+# deserialization stack.
+# There is also an 'open' stack that is used to resolve circular references.
+# Objects or arrays may contain self-references. Before we begin to deserialize
+# the contents of these values, they are first given object reference IDs (by
+# GenerateFreshObjectTag/GenerateFreshArrayTag); these reference IDs are then
+# used with ObjectReferenceTag to tie the recursive knot.
+
+__version__ = "0.3"
+__description__ = "Partial reimplementation of the Blink Javascript Object Serialization"
+__contact__ = "Alex Caithness"
+
+__DEBUG = False
+
+
+def log(msg, debug_only=True):
+    if __DEBUG or not debug_only:
+        caller_name = sys._getframe(1).f_code.co_name
+        caller_line = sys._getframe(1).f_code.co_firstlineno
+        print(f"{caller_name} ({caller_line}):\t{msg}")
+
+
+class BlobIndexType(enum.Enum):
+    Blob = 0
+    File = 1
+
+
+@dataclass
+class BlobIndex:
+    index_type: BlobIndexType
+    index_id: int
+
+
+@dataclass(frozen=True)
+class NativeFileHandle:
+    is_dir: bool
+    name: str
+    token_index: int
+
+
+@dataclass(frozen=True)
+class CryptoKey:
+    sub_type: "V8CryptoKeySubType"
+    algorithm_type: typing.Optional["V8CryptoKeyAlgorithm"]
+    hash_type: typing.Optional["V8CryptoKeyAlgorithm"]
+    asymmetric_key_type: typing.Optional["V8AsymmetricCryptoKeyType"]
+    byte_length: typing.Optional[int]
+    public_exponent: typing.Optional[bytes]
+    named_curve_type: typing.Optional["V8CryptoNamedCurve"]
+    key_usage: "V8CryptoKeyUsage"
+    key_data: bytes
+
+
+class Constants:
+    tag_kMessagePortTag = b"M"  # index:int -> MessagePort. Fills the result with
+                                # transferred MessagePort.
+    tag_kMojoHandleTag = b"h"   # index:int -> MojoHandle. Fills the result with
+                                # transferred MojoHandle.
+    tag_kBlobTag = b"b"         # uuid:WebCoreString, type:WebCoreString, size:uint64_t ->
+                                # Blob (ref)
+    tag_kBlobIndexTag = b"i"    # index:int32_t -> Blob (ref)
+    tag_kFileTag = b"f"         # file:RawFile -> File (ref)
+    tag_kFileIndexTag = b"e"    # index:int32_t -> File (ref)
+    tag_kDOMFileSystemTag = b"d"  # type : int32_t, name:WebCoreString,
+                                  # uuid:WebCoreString -> FileSystem (ref)
+    tag_kNativeFileSystemFileHandleTag = b"n"  # name:WebCoreString, index:uint32_t
+                                               # -> NativeFileSystemFileHandle (ref)
+    tag_kNativeFileSystemDirectoryHandleTag = b"N"  # name:WebCoreString, index:uint32_t ->
+                                                   # NativeFileSystemDirectoryHandle (ref)
+    tag_kFileListTag = b"l"                     # length:uint32_t, files:RawFile[length] -> FileList (ref)
+    tag_kFileListIndexTag = b"L"                # length:uint32_t, files:int32_t[length] -> FileList (ref)
+    tag_kImageDataTag = b"#"                   # tags terminated by ImageSerializationTag::kEnd (see
+                                               # SerializedColorParams.h), width:uint32_t,
+                                               # height:uint32_t, pixelDataLength:uint64_t,
+                                               # data:byte[pixelDataLength]
+                                               # -> ImageData (ref)
+    tag_kImageBitmapTag = b"g"        # tags terminated by ImageSerializationTag::kEnd (see
+                                      # SerializedColorParams.h), width:uint32_t,
+                                      # height:uint32_t, pixelDataLength:uint32_t,
+                                      # data:byte[pixelDataLength]
+                                      # -> ImageBitmap (ref)
+    tag_kImageBitmapTransferTag = b"G"      # index:uint32_t -> ImageBitmap. For ImageBitmap transfer
+    tag_kOffscreenCanvasTransferTag = b"H"  # index, width, height, id,
+                                            # filter_quality::uint32_t ->
+                                            # OffscreenCanvas. For OffscreenCanvas
+                                            # transfer
+    tag_kReadableStreamTransferTag = b"r"    # index:uint32_t
+    tag_kTransformStreamTransferTag = b"m"   # index:uint32_t
+    tag_kWritableStreamTransferTag = b"w"    # index:uint32_t
+    tag_kDOMPointTag = b"Q"                  # x:Double, y:Double, z:Double, w:Double
+    tag_kDOMPointReadOnlyTag = b"W"          # x:Double, y:Double, z:Double, w:Double
+    tag_kDOMRectTag = b"E"                   # x:Double, y:Double, width:Double, height:Double
+    tag_kDOMRectReadOnlyTag = b"R"           # x:Double, y:Double, width:Double, height:Double
+    tag_kDOMQuadTag = b"T"                   # p1:Double, p2:Double, p3:Double, p4:Double
+    tag_kDOMMatrixTag = b"Y"                 # m11..m44: 16 Double
+    tag_kDOMMatrixReadOnlyTag = b"U"         # m11..m44: 16 Double
+    tag_kDOMMatrix2DTag = b"I"               # a..f: 6 Double
+    tag_kDOMMatrix2DReadOnlyTag = b"O"       # a..f: 6 Double
+    tag_kCryptoKeyTag = b"K"                 # subtag:byte, props, usages:uint32_t,
+    # keyDataLength:uint32_t, keyData:byte[keyDataLength]
+    #                 If subtag=AesKeyTag:
+    #                     props = keyLengthBytes:uint32_t, algorithmId:uint32_t
+    #                 If subtag=HmacKeyTag:
+    #                     props = keyLengthBytes:uint32_t, hashId:uint32_t
+    #                 If subtag=RsaHashedKeyTag:
+    #                     props = algorithmId:uint32_t, type:uint32_t,
+    #                     modulusLengthBits:uint32_t,
+    #                     publicExponentLength:uint32_t,
+    #                     publicExponent:byte[publicExponentLength],
+    #                     hashId:uint32_t
+    #                 If subtag=EcKeyTag:
+    #                     props = algorithmId:uint32_t, type:uint32_t,
+    #                     namedCurve:uint32_t
+    tag_kRTCCertificateTag = b"k"  # length:uint32_t, pemPrivateKey:WebCoreString,
+    # pemCertificate:WebCoreString
+    tag_kRTCEncodedAudioFrameTag = b"A"  # uint32_t -> transferred audio frame ID
+    tag_kRTCEncodedVideoFrameTag = b"V"  # uint32_t -> transferred video frame ID
+    tag_kVideoFrameTag = b"v"            # uint32_t -> transferred video frame ID
+
+    # The following tags were used by the Shape Detection API implementation
+    # between M71 and M81. During these milestones, the API was always behind
+    # a flag. Usage was removed in https:#crrev.com/c/2040378.
+    tag_kDeprecatedDetectedBarcodeTag = b"B"
+    tag_kDeprecatedDetectedFaceTag = b"F"
+    tag_kDeprecatedDetectedTextTag = b"t"
+
+    tag_kDOMExceptionTag = b"x"  # name:String,message:String,stack:String
+    tag_kVersionTag = b"\xff"  # version:uint32_t -> Uses this as the file version.
+    tag_kTrailerOffsetTag = b"\xfe" # offset:uint64_t (fixed width, network order) from buffer, start size:uint32_t (fixed width, network order)
+    tag_kTrailerRequiresInterfacesTag = b"\xA0"
+
+
+class V8CryptoKeySubType(enum.IntEnum):
+    """
+    See: third_party/blink/renderer/bindings/modules/v8/serialization/web_crypto_sub_tags.h
+    Used by the kCryptoKeyTag type
+    """
+    AesKey = 1
+    HmacKey = 2
+    # ID 3 was used by RsaKeyTag, while still behind experimental flag.
+    RsaHashedKey = 4
+    EcKey = 5
+    NoParamsKey = 6
+
+
+class V8CryptoKeyAlgorithm(enum.IntEnum):
+    """
+    See: third_party/blink/renderer/bindings/modules/v8/serialization/web_crypto_sub_tags.h
+    Used by the kCryptoKeyTag type
+    """
+    AesCbcTag = 1
+    HmacTag = 2
+    RsaSsaPkcs1v1_5Tag = 3
+    # ID 4 was used by RsaEs, while still behind experimental flag.
+    Sha1Tag = 5
+    Sha256Tag = 6
+    Sha384Tag = 7
+    Sha512Tag = 8
+    AesGcmTag = 9
+    RsaOaepTag = 10
+    AesCtrTag = 11
+    AesKwTag = 12
+    RsaPssTag = 13
+    EcdsaTag = 14
+    EcdhTag = 15
+    HkdfTag = 16
+    Pbkdf2Tag = 17
+
+
+class V8AsymmetricCryptoKeyType(enum.IntEnum):
+    Public = 1
+    Private = 2
+
+
+class V8CryptoNamedCurve(enum.IntEnum):
+    """
+    See: third_party/blink/renderer/bindings/modules/v8/serialization/web_crypto_sub_tags.h
+    Used by the kCryptoKeyTag type
+    """
+    P256 = 1
+    P384 = 2
+    P521 = 3
+
+
+class V8CryptoKeyUsage(enum.IntFlag):
+    """
+    See: third_party/blink/renderer/bindings/modules/v8/serialization/web_crypto_sub_tags.h
+    Used by the kCryptoKeyTag type
+    """
+    kExtractableUsage = 1 << 0
+    kEncryptUsage = 1 << 1
+    kDecryptUsage = 1 << 2
+    kSignUsage = 1 << 3
+    kVerifyUsage = 1 << 4
+    kDeriveKeyUsage = 1 << 5
+    kWrapKeyUsage = 1 << 6
+    kUnwrapKeyUsage = 1 << 7
+    kDeriveBitsUsage = 1 << 8
+
+
+class BlinkV8Deserializer:
+    def _read_varint(self, stream) -> int:
+        return ccl_v8_value_deserializer.read_le_varint(stream)[0]
+
+    def _read_varint32(self, stream) -> int:
+        return ccl_v8_value_deserializer.read_le_varint(stream, is_32bit=True)[0]
+
+    def _read_utf8_string(self, stream: typing.BinaryIO) -> str:
+        length = self._read_varint32(stream)
+        raw_string = stream.read(length)
+        if len(raw_string) != length:
+            raise ValueError("Could not read all of the utf-8 data")
+        return raw_string.decode("utf-8")
+
+    # def _read_uint32(self, stream: typing.BinaryIO) -> int:
+    #     raw = stream.read(4)
+    #     if len(raw) < 4:
+    #         raise ValueError("Could not read enough data when reading int32")
+    #     return struct.unpack("<I", raw)[0]
+
+    def _read_file_index(self, stream: typing.BinaryIO) -> BlobIndex:
+        return BlobIndex(BlobIndexType.File, self._read_varint(stream))
+
+    def _read_blob_index(self, stream: typing.BinaryIO) -> BlobIndex:
+        return BlobIndex(BlobIndexType.Blob, self._read_varint(stream))
+
+    def _read_file_list_index(self, stream: typing.BinaryIO) -> typing.Iterable[BlobIndex]:
+        length = self._read_varint(stream)
+        result = [self._read_file_index(stream) for _ in range(length)]
+        return result
+
+    def _read_native_file_handle(self, is_dir: bool, stream: typing.BinaryIO) -> NativeFileHandle:
+        return NativeFileHandle(is_dir, self._read_utf8_string(stream), self._read_varint(stream))
+
+    def _read_crypto_key(self, stream: typing.BinaryIO):
+        sub_type = V8CryptoKeySubType(stream.read(1)[0])
+
+        if sub_type == V8CryptoKeySubType.AesKey:
+            algorithm_id = V8CryptoKeyAlgorithm(self._read_varint32(stream))
+            byte_length = self._read_varint32(stream)
+            params = {
+                "algorithm_type": algorithm_id,
+                "byte_length": byte_length,
+                "hash_type": None,
+                "named_curve_type": None,
+                "asymmetric_key_type": None,
+                "public_exponent": None
+            }
+        elif sub_type == V8CryptoKeySubType.HmacKey:
+            byte_length = self._read_varint32(stream)
+            hash_id = V8CryptoKeyAlgorithm(self._read_varint32(stream))
+            params = {
+                "byte_length": byte_length,
+                "hash_type": hash_id,
+                "algorithm_type": None,
+                "named_curve_type": None,
+                "asymmetric_key_type": None,
+                "public_exponent": None
+            }
+        elif sub_type == V8CryptoKeySubType.RsaHashedKey:
+            algorithm_id = V8CryptoKeyAlgorithm(self._read_varint32(stream))
+            asymmetric_key_type = V8AsymmetricCryptoKeyType(stream.read(1)[0])
+            length_bytes = self._read_varint32(stream)
+            public_exponent_length = self._read_varint32(stream)
+            public_exponent = stream.read(public_exponent_length)
+            if len(public_exponent) != public_exponent_length:
+                raise ValueError(f"Could not read all of public exponent data")
+            hash_id = V8CryptoKeyAlgorithm(self._read_varint32(stream))
+            params = {
+                "algorithm_type": algorithm_id,
+                "asymmetric_key_type": asymmetric_key_type,
+                "byte_length": length_bytes,
+                "public_exponent": public_exponent,
+                "hash_type": hash_id,
+                "named_curve_type": None
+            }
+
+        elif sub_type == V8CryptoKeySubType.EcKey:
+            algorithm_id = V8CryptoKeyAlgorithm(self._read_varint32(stream))
+            asymmetric_key_type = V8AsymmetricCryptoKeyType(stream.read(1)[0])
+            named_curve = V8CryptoNamedCurve(self._read_varint32(stream))
+            params = {
+                "algorithm_type": algorithm_id,
+                "asymmetric_key_type": asymmetric_key_type,
+                "named_curve_type": named_curve,
+                "hash_type": None,
+                "byte_length": None,
+                "public_exponent": None
+            }
+        elif sub_type == V8CryptoKeySubType.NoParamsKey:
+            algorithm_id = V8CryptoKeyAlgorithm(self._read_varint32(stream))
+            params = {
+                "algorithm_type": algorithm_id,
+                "hash_type": None,
+                "asymmetric_key_type": None,
+                "byte_length": None,
+                "named_curve_type": None,
+                "public_exponent": None
+            }
+        else:
+            raise ValueError(f"Unknown V8CryptoKeySubType {sub_type}")
+
+        params["key_usage"] = V8CryptoKeyUsage(self._read_varint32(stream))
+        key_length = self._read_varint32(stream)
+        key_data = stream.read(key_length)
+        if len(key_data) < key_length:
+            raise ValueError("Could not read all key data")
+
+        params["key_data"] = key_data
+        return CryptoKey(sub_type, **params)
+
+    def _not_implemented(self, stream):
+        raise NotImplementedError()
+
+    def read(self, stream: typing.BinaryIO) -> typing.Any:
+        tag = stream.read(1)
+
+        func = {
+            Constants.tag_kMessagePortTag: lambda x: self._not_implemented(x),
+            Constants.tag_kMojoHandleTag: lambda x: self._not_implemented(x),
+            Constants.tag_kBlobTag: lambda x: self._not_implemented(x),
+            Constants.tag_kBlobIndexTag: lambda x: self._read_blob_index(x),
+            Constants.tag_kFileTag: lambda x: self._not_implemented(x),
+            Constants.tag_kFileIndexTag: lambda x: self._read_file_index(x),
+            Constants.tag_kDOMFileSystemTag: lambda x: self._not_implemented(x),
+            Constants.tag_kNativeFileSystemFileHandleTag: lambda x: self._read_native_file_handle(False, x),
+            Constants.tag_kNativeFileSystemDirectoryHandleTag: lambda x: self._read_native_file_handle(True, x),
+            Constants.tag_kFileListTag: lambda x: self._not_implemented(x),
+            Constants.tag_kFileListIndexTag: lambda x: self._read_file_list_index(x),
+            Constants.tag_kImageDataTag: lambda x: self._not_implemented(x),
+            Constants.tag_kImageBitmapTag: lambda x: self._not_implemented(x),
+            Constants.tag_kImageBitmapTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kOffscreenCanvasTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kReadableStreamTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kTransformStreamTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kWritableStreamTransferTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMPointTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMPointReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMRectTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMRectReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMQuadTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrixTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrixReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrix2DTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMMatrix2DReadOnlyTag: lambda x: self._not_implemented(x),
+            Constants.tag_kCryptoKeyTag: lambda x: self._read_crypto_key(x),
+            Constants.tag_kRTCCertificateTag: lambda x: self._not_implemented(x),
+            Constants.tag_kRTCEncodedAudioFrameTag: lambda x: self._not_implemented(x),
+            Constants.tag_kRTCEncodedVideoFrameTag: lambda x: self._not_implemented(x),
+            Constants.tag_kVideoFrameTag: lambda x: self._not_implemented(x),
+            Constants.tag_kDOMExceptionTag: lambda x: self._not_implemented(x)
+        }.get(tag)
+
+        if func is None:
+            raise ValueError(f"Unknown tag: {tag}")
+
+        return func(stream)

--- a/scripts/ccl/ccl_chromium_indexeddb.py
+++ b/scripts/ccl/ccl_chromium_indexeddb.py
@@ -1,0 +1,1081 @@
+"""
+Copyright 2020-2024, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# Vendored from CCL Forensics. Only the package-relative imports are changed,
+# to match this repo's flat scripts/ccl layout.
+# pylint: skip-file
+
+import sys
+import struct
+import os
+import pathlib
+import io
+import enum
+import datetime
+import dataclasses
+import types
+import typing
+
+from scripts.ccl import ccl_simplesnappy
+
+from scripts.ccl.ccl_structures import ArtifactLocation
+from scripts.ccl import ccl_leveldb
+from scripts.ccl import ccl_blink_value_deserializer, ccl_v8_value_deserializer
+
+__version__ = "0.21"
+__description__ = "Module for reading Chromium IndexedDB LevelDB databases."
+__contact__ = "Alex Caithness"
+
+
+# TODO: need to go through and ensure that we have endianness right in all cases
+#  (it should sit behind a switch for integers, fixed for most other stuff)
+
+
+def _read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False) -> typing.Optional[tuple[int, bytes]]:
+    # this only outputs unsigned
+    i = 0
+    result = 0
+    underlying_bytes = []
+    limit = 5 if is_google_32bit else 10
+    while i < limit:
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+def read_le_varint(stream: typing.BinaryIO, *, is_google_32bit=False) -> typing.Optional[int]:
+    x = _read_le_varint(stream, is_google_32bit=is_google_32bit)
+    if x is None:
+        return None
+    else:
+        return x[0]
+
+
+def _le_varint_from_bytes(data: bytes) -> typing.Optional[tuple[int, bytes]]:
+    with io.BytesIO(data) as buff:
+        return _read_le_varint(buff)
+
+
+def le_varint_from_bytes(data: bytes) -> typing.Optional[int]:
+    with io.BytesIO(data) as buff:
+        return read_le_varint(buff)
+
+
+def decode_truncated_int(data: bytes) -> int:
+    # See: /content/browser/indexed_db/indexed_db_leveldb_coding.h EncodeInt()
+    # "// Unlike EncodeVarInt, this is a 'dumb' implementation of a variable int
+    # // encoder. It writes, little-endian', until there are no more '1' bits in the
+    # // number. The Decoder must know how to calculate the size of the encoded int,
+    # // typically by having this reside at the end of the value or key."
+    if len(data) == 0:
+        raise ValueError("No data to decode")
+    result = 0
+    for i, b in enumerate(data):
+        result |= (b << (i * 8))
+    return result
+
+
+class IdbKeyType(enum.IntEnum):
+    Null = 0
+    String = 1
+    Date = 2
+    Number = 3
+    Array = 4
+    MinKey = 5
+    Binary = 6
+
+
+class IdbKey:
+    # See: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/indexed_db_leveldb_coding.cc
+    def __init__(self, buffer: bytes):
+        self.raw_key = buffer
+        self.key_type = IdbKeyType(buffer[0])
+        raw_key = buffer[1:]
+
+        if self.key_type == IdbKeyType.Null:
+            self.value = None
+            self._raw_length = 1
+        elif self.key_type == IdbKeyType.String:
+            str_len, varint_raw = _le_varint_from_bytes(raw_key)
+            self.value = raw_key[len(varint_raw):len(varint_raw) + str_len * 2].decode("utf-16-be")
+            self._raw_length = 1 + len(varint_raw) + str_len * 2
+        elif self.key_type == IdbKeyType.Date:
+            ts, = struct.unpack("<d", raw_key[0:8])
+            self.value = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=ts)
+            self._raw_length = 9
+        elif self.key_type == IdbKeyType.Number:
+            self.value = struct.unpack("<d", raw_key[0:8])[0]
+            self._raw_length = 9
+        elif self.key_type == IdbKeyType.Array:
+            array_count, varint_raw = _le_varint_from_bytes(raw_key)
+            raw_key = raw_key[len(varint_raw):]
+            self.value = []
+            self._raw_length = 1 + len(varint_raw)
+            for i in range(array_count):
+                key = IdbKey(raw_key)
+                raw_key = raw_key[key._raw_length:]
+                self._raw_length += key._raw_length
+                self.value.append(key)
+            self.value = tuple(self.value)
+        elif self.key_type == IdbKeyType.MinKey:
+            # TODO: not sure what this actually implies, the code doesn't store a value
+            self.value = None
+            self._raw_length = 1
+            raise NotImplementedError()
+        elif self.key_type == IdbKeyType.Binary:
+            bin_len, varint_raw = _le_varint_from_bytes(raw_key)
+            self.value = raw_key[len(varint_raw):len(varint_raw) + bin_len]
+            self._raw_length = 1 + len(varint_raw) + bin_len
+        else:
+            raise ValueError()  # Shouldn't happen
+
+        # trim the raw_key in case this is an inner key:
+        self.raw_key = self.raw_key[0: self._raw_length]
+
+    def __repr__(self):
+        return f"<IdbKey {self.value}>"
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        if not isinstance(other, IdbKey):
+            raise NotImplementedError()
+        return self.raw_key == other.raw_key
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __hash__(self):
+        return self.raw_key.__hash__()
+
+
+class IndexedDBExternalObjectType(enum.IntEnum):
+    # see: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/indexed_db_external_object.h
+    Blob = 0
+    File = 1
+    NativeFileSystemHandle = 2
+
+
+class IndexedDBExternalObject:
+    # see: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/indexed_db_backing_store.cc
+    # for encoding.
+
+    def __init__(self, object_type: IndexedDBExternalObjectType, blob_number: typing.Optional[int],
+                 mime_type: typing.Optional[str], size: typing.Optional[int],
+                 file_name: typing.Optional[str], last_modified: typing.Optional[datetime.datetime],
+                 native_file_token: typing.Optional):
+        self.object_type = object_type
+        self.blob_number = blob_number
+        self.mime_type = mime_type
+        self.size = size
+        self.file_name = file_name
+        self.last_modified = last_modified
+        self.native_file_token = native_file_token
+
+    @classmethod
+    def from_stream(cls, stream: typing.BinaryIO):
+        blob_type = IndexedDBExternalObjectType(stream.read(1)[0])
+        if blob_type in (IndexedDBExternalObjectType.Blob, IndexedDBExternalObjectType.File):
+            blob_number = read_le_varint(stream)
+            mime_type_length = read_le_varint(stream)
+            mime_type = stream.read(mime_type_length * 2).decode("utf-16-be")
+            data_size = read_le_varint(stream)
+
+            if blob_type == IndexedDBExternalObjectType.File:
+                file_name_length = read_le_varint(stream)
+                file_name = stream.read(file_name_length * 2).decode("utf-16-be")
+                x, x_raw = _read_le_varint(stream)
+                last_modified_td = datetime.timedelta(microseconds=x)
+                last_modified = datetime.datetime(1601, 1, 1) + last_modified_td
+                return cls(blob_type, blob_number, mime_type, data_size, file_name,
+                           last_modified, None)
+            else:
+                return cls(blob_type, blob_number, mime_type, data_size, None, None, None)
+        else:
+            raise NotImplementedError()
+
+
+@dataclasses.dataclass(frozen=True)
+class DatabaseId:
+    dbid_no: int
+    origin: str
+    name: str
+
+
+class GlobalMetadata:
+    def __init__(self, raw_meta_dict: dict):
+        # TODO: more of these meta types if required
+        self.backing_store_schema_version = None
+        if raw_schema_version := raw_meta_dict.get("\x00\x00\x00\x00\x00"):
+            self.backing_store_schema_version = le_varint_from_bytes(raw_schema_version)
+
+        self.max_allocated_db_id = None
+        if raw_max_db_id := raw_meta_dict.get("\x00\x00\x00\x00\x01"):
+            self.max_allocated_db_id = le_varint_from_bytes(raw_max_db_id)
+
+        database_ids_raw = (raw_meta_dict[x] for x in raw_meta_dict
+                            if x.startswith(b"\x00\x00\x00\x00\xc9"))
+
+        dbids = []
+        for dbid_rec in database_ids_raw:
+            with io.BytesIO(dbid_rec.key[5:]) as buff:
+                origin_length = read_le_varint(buff)
+                origin = buff.read(origin_length * 2).decode("utf-16-be")
+                db_name_length = read_le_varint(buff)
+                db_name = buff.read(db_name_length * 2).decode("utf-16-be")
+
+            db_id_no = decode_truncated_int(dbid_rec.value)
+
+            dbids.append(DatabaseId(db_id_no, origin, db_name))
+
+        self._db_ids = tuple(dbids)
+        self._db_ids_lookup = types.MappingProxyType({x.dbid_no: x for x in self._db_ids})
+
+    @property
+    def db_ids(self) -> tuple[DatabaseId, ...]:
+        return self._db_ids
+
+    @property
+    def db_ids_lookup(self) -> dict[int: DatabaseId]:
+        return self._db_ids_lookup
+
+
+class DatabaseMetadataType(enum.IntEnum):
+    OriginName = 0  # String
+    DatabaseName = 1  # String
+    IdbVersionString = 2  # String (and obsolete)
+    MaximumObjectStoreId = 3  # Int
+    IdbVersion = 4  # Varint
+    BlobNumberGeneratorCurrentNumber = 5  # Varint
+
+
+class DatabaseMetadata:
+    def __init__(self, raw_meta: dict):
+        self._metas = types.MappingProxyType(raw_meta)
+
+    def get_meta(self, db_id: int, meta_type: DatabaseMetadataType) -> typing.Optional[typing.Union[str, int]]:
+        record = self._metas.get((db_id, meta_type))
+        if not record:
+            return None
+
+        if meta_type == DatabaseMetadataType.MaximumObjectStoreId:
+            return decode_truncated_int(record.value)
+
+        # TODO
+        raise NotImplementedError()
+
+
+class ObjectStoreMetadataType(enum.IntEnum):
+    StoreName = 0  # String
+    KeyPath = 1  # IDBKeyPath
+    AutoIncrementFlag = 2  # Bool
+    IsEvictable = 3  # Bool (and obsolete apparently)
+    LastVersionNumber = 4  # Int
+    MaximumAllocatedIndexId = 5  # Int
+    HasKeyPathFlag = 6  # Bool (and obsolete apparently)
+    KeygeneratorCurrentNumber = 7  # Int
+
+
+class ObjectStoreMetadata:
+    # All metadata fields are prefaced by a 0x00 byte
+    def __init__(self, raw_meta: dict):
+        self._metas = types.MappingProxyType(raw_meta)
+
+    def get_meta(self, db_id: int, obj_store_id: int, meta_type: ObjectStoreMetadataType):
+        record = self._metas.get((db_id, obj_store_id, meta_type))
+        if not record:
+            return None
+
+        if meta_type == ObjectStoreMetadataType.StoreName:
+            return record.value.decode("utf-16-be")
+
+        # TODO
+        raise NotImplementedError()
+
+
+@dataclasses.dataclass(frozen=True)
+class BlinkTrailer:
+    # third_party/blink/renderer/bindings/core/v8/serialization/trailer_reader.h
+    offset: int
+    length: int
+
+    TRAILER_SIZE: typing.ClassVar[int] = 13
+    MIN_WIRE_FORMAT_VERSION_FOR_TRAILER: typing.ClassVar[int] = 21
+
+    @classmethod
+    def from_buffer(cls, buffer, trailer_offset: int):
+        tag, offset, length = struct.unpack(">cQI", buffer[trailer_offset: trailer_offset + BlinkTrailer.TRAILER_SIZE])
+        if tag != ccl_blink_value_deserializer.Constants.tag_kTrailerOffsetTag:
+            raise ValueError(
+                f"Trailer doesn't start with kTrailerOffsetTag "
+                f"(expected: 0x{ccl_blink_value_deserializer.Constants.tag_kTrailerOffsetTag.hex()}; "
+                f"got: 0x{tag.hex()}")
+
+        return BlinkTrailer(offset, length)
+
+
+@dataclasses.dataclass(frozen=True)
+class IndexedDbRecord:
+    owner: "IndexedDb"
+    db_id: int
+    obj_store_id: int
+    key: IdbKey
+    value: typing.Any
+    is_live: bool
+    ldb_seq_no: int
+    origin_file: os.PathLike
+    external_value_path: typing.Optional[str] = None
+
+    def resolve_blob_index(self, blob_index: ccl_blink_value_deserializer.BlobIndex) -> IndexedDBExternalObject:
+        """Resolve a ccl_blink_value_deserializer.BlobIndex to its IndexedDBExternalObject
+         to get metadata (file name, timestamps, etc)"""
+        return self.owner.get_blob_info(self.db_id, self.obj_store_id, self.key.raw_key, blob_index.index_id)
+
+    def get_blob_stream(self, blob_index: ccl_blink_value_deserializer.BlobIndex) -> typing.BinaryIO:
+        """Resolve a ccl_blink_value_deserializer.BlobIndex to a stream of its content"""
+        return self.owner.get_blob(self.db_id, self.obj_store_id, self.key.raw_key, blob_index.index_id)
+
+    @property
+    def database_name(self):
+        return self.owner.global_metadata.db_ids_lookup[self.db_id].name
+
+    @property
+    def database_origin(self):
+        return self.owner.global_metadata.db_ids_lookup[self.db_id].origin
+
+    @property
+    def object_store_name(self):
+        return self.owner.get_object_store_metadata(self.db_id, self.obj_store_id, ObjectStoreMetadataType.StoreName)
+
+    @property
+    def record_location(self) -> ArtifactLocation:
+        return ArtifactLocation(
+            str(self.origin_file),
+            None,
+            f"File: {pathlib.Path(*pathlib.Path(self.origin_file).parts[-2:])} Seq: {self.ldb_seq_no}")
+
+
+class IndexedDb:
+    # This will be informative for a lot of the data below:
+    # https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/docs/leveldb_coding_scheme.md
+
+    # Of note, the first byte of the key defines the length of the db_id, obj_store_id and index_id in bytes:
+    # 0b xxxyyyzz (x = db_id size - 1, y = obj_store size - 1, z = index_id - 1)
+
+    def __init__(self, leveldb_dir: os.PathLike, leveldb_blob_dir: os.PathLike = None):
+        self._db = ccl_leveldb.RawLevelDb(leveldb_dir)
+        self._blob_dir = leveldb_blob_dir
+        self.global_metadata: typing.Optional[GlobalMetadata] = None
+        self.database_metadata: typing.Optional[DatabaseMetadata] = None
+        self.object_store_meta: typing.Optional[ObjectStoreMetadata] = None
+        self._cache_records()
+        self._fetch_meta_data()
+        self._blob_lookup_cache = {}
+
+    def _cache_records(self):
+        self._fetched_records = []
+        # Fetch the records only once
+        for record in self._db.iterate_records_raw():
+            self._fetched_records.append(record)
+
+    def _fetch_meta_data(self):
+        global_metadata_raw = self._get_raw_global_metadata()
+        self.global_metadata = GlobalMetadata(global_metadata_raw)
+        database_metadata_raw = self._get_raw_database_metadata()
+        self.database_metadata = DatabaseMetadata(database_metadata_raw)
+        objectstore_metadata_raw = self._get_raw_object_store_metadata()
+        self.object_store_meta = ObjectStoreMetadata(objectstore_metadata_raw)
+
+    @staticmethod
+    def make_prefix(
+            db_id: int, obj_store_id: int, index_id: int, end: typing.Optional[typing.Sequence[int]]=None) -> bytes:
+        if end is None:
+            end = []
+
+        def count_bytes(val):
+            if val == 0:
+                return 1
+            i = 0
+            while val > 0:
+                i += 1
+                val = val >> 8
+            return i
+
+        def yield_le_bytes(val):
+            if val == 0:
+                yield 0
+            if val < 0:
+                raise ValueError
+            while val > 0:
+                yield val & 0xff
+                val = val >> 8
+
+        db_id_size = count_bytes(db_id)
+        obj_store_id_size = count_bytes(obj_store_id)
+        index_id_size = count_bytes(index_id)
+
+        if db_id_size > 8 or obj_store_id_size > 8 or index_id_size > 4:
+            raise ValueError("id sizes are too big")
+
+        byte_one = ((db_id_size - 1) << 5) | ((obj_store_id_size - 1) << 2) | (index_id_size - 1)
+        # print([byte_one, *yield_le_bytes(db_id), *yield_le_bytes(obj_store_id), *yield_le_bytes(index_id), *end])
+        return bytes([byte_one, *yield_le_bytes(db_id), *yield_le_bytes(obj_store_id), *yield_le_bytes(index_id), *end])
+
+    @staticmethod
+    def read_prefix(stream: typing.BinaryIO) -> tuple[int, int, int, int]:
+        """
+        :param stream: file-like to read the prefix from
+        :return: a tuple of db_id, object_store_id, index_id, length of the prefix
+        """
+        lengths_bytes = stream.read(1)
+        if not lengths_bytes:
+            raise ValueError("Couldn't get enough data when reading prefix length")
+        lengths = lengths_bytes[0]
+        db_id_size = ((lengths >> 5) & 0x07) + 1
+        object_store_size = ((lengths >> 2) & 0x07) + 1
+        index_size = (lengths & 0x03) + 1
+
+        db_id_raw = stream.read(db_id_size)
+        object_store_raw = stream.read(object_store_size)
+        index_raw = stream.read(index_size)
+
+        if (len(db_id_raw) != db_id_size or
+                len(object_store_raw) != object_store_size or
+                len(index_raw) != index_size):
+            raise ValueError("Couldn't read enough bytes for the prefix")
+
+        db_id = int.from_bytes(db_id_raw, "little")
+        object_store_id = int.from_bytes(object_store_raw, "little")
+        index_id = int.from_bytes(index_raw, "little")
+
+        return db_id, object_store_id, index_id, (db_id_size + object_store_size + index_size + 1)
+
+    def get_database_metadata(self, db_id: int, meta_type: DatabaseMetadataType):
+        return self.database_metadata.get_meta(db_id, meta_type)
+
+    def get_object_store_metadata(self, db_id: int, obj_store_id: int, meta_type: ObjectStoreMetadataType):
+        return self.object_store_meta.get_meta(db_id, obj_store_id, meta_type)
+
+    def _get_raw_global_metadata(self, live_only=True) -> typing.Dict[bytes, ccl_leveldb.Record]:
+        # Global metadata always has the prefix 0 0 0 0
+        if not live_only:
+            raise NotImplementedError("Deleted metadata not implemented yet")
+        meta = {}
+        for record in reversed(self._fetched_records):
+            if record.key.startswith(b"\x00\x00\x00\x00") and record.state == ccl_leveldb.KeyState.Live:
+                # we only want live keys and the newest version thereof (highest seq)
+                if record.key not in meta or meta[record.key].seq < record.seq:
+                    meta[record.key] = record
+
+        return meta
+
+    def _get_raw_database_metadata(self, live_only=True):
+        if not live_only:
+            raise NotImplementedError("Deleted metadata not implemented yet")
+
+        db_meta = {}
+
+        for db_id in self.global_metadata.db_ids:
+
+            prefix = IndexedDb.make_prefix(db_id.dbid_no, 0, 0)
+            for record in reversed(self._fetched_records):
+                if record.key.startswith(prefix) and record.state == ccl_leveldb.KeyState.Live:
+                    # we only want live keys and the newest version thereof (highest seq)
+                    meta_type = record.key[len(prefix)]
+                    old_version = db_meta.get((db_id.dbid_no, meta_type))
+                    if old_version is None or old_version.seq < record.seq:
+                        db_meta[(db_id.dbid_no, meta_type)] = record
+
+        return db_meta
+
+    def _get_raw_object_store_metadata(self, live_only=True):
+        if not live_only:
+            raise NotImplementedError("Deleted metadata not implemented yet")
+
+        os_meta = {}
+
+        for db_id in self.global_metadata.db_ids:
+
+            prefix = IndexedDb.make_prefix(db_id.dbid_no, 0, 0, [50])
+
+            for record in reversed(self._fetched_records):
+                if record.key.startswith(prefix) and record.state == ccl_leveldb.KeyState.Live:
+                    # we only want live keys and the newest version thereof (highest seq)
+                    objstore_id, varint_raw = _le_varint_from_bytes(record.key[len(prefix):])
+                    meta_type = record.key[len(prefix) + len(varint_raw)]
+
+                    old_version = os_meta.get((db_id.dbid_no, objstore_id, meta_type))
+
+                    if old_version is None or old_version.seq < record.seq:
+                        os_meta[(db_id.dbid_no, objstore_id, meta_type)] = record
+
+        return os_meta
+
+    def read_record_precursor(
+            self, key: IdbKey, db_id: int, store_id: int, buffer: bytes,
+            bad_deserializer_data_handler: typing.Callable[[IdbKey, bytes], typing.Any],
+            external_data_path: typing.Optional[str] = None):
+        val_idx = 0
+        trailer = None
+        blink_type_tag = buffer[val_idx]
+        if blink_type_tag != 0xff:
+            # TODO: probably don't want to fail hard here long term...
+            if bad_deserializer_data_handler is not None:
+                bad_deserializer_data_handler(key, buffer)
+                return None
+            else:
+                raise ValueError("Blink type tag not present")
+
+        val_idx += 1
+
+        blink_version, varint_raw = _le_varint_from_bytes(buffer[val_idx:])
+
+        val_idx += len(varint_raw)
+
+        # third_party/blink/renderer/modules/indexeddb/idb_value_wrapping.cc
+        # Peek the next byte to work out if the data is held externally or compressed:
+        if blink_version == 0x11:
+            if buffer[val_idx] == 0x01:  # kReplaceWithBlob
+                val_idx += 1
+                externally_serialized_blob_size, varint_raw = _le_varint_from_bytes(buffer[val_idx:])
+                val_idx += len(varint_raw)
+                externally_serialized_blob_index, varint_raw = _le_varint_from_bytes(buffer[val_idx:])
+                val_idx += len(varint_raw)
+
+                try:
+                    info = self.get_blob_info(db_id, store_id, key.raw_key, externally_serialized_blob_index)
+                except KeyError:
+                    info = None
+
+                if info is not None:
+                    data_path = pathlib.Path(str(db_id), f"{info.blob_number >> 8:02x}", f"{info.blob_number:x}")
+                    try:
+                        blob = self.get_blob(db_id, store_id, key.raw_key, externally_serialized_blob_index).read()
+                    except FileNotFoundError:
+                        if bad_deserializer_data_handler is not None:
+                            bad_deserializer_data_handler(key, buffer)
+                            return None
+                        raise
+
+                    return self.read_record_precursor(
+                        key, db_id, store_id,
+                        blob,
+                        bad_deserializer_data_handler, str(data_path))
+                else:
+                    return None
+
+            elif buffer[val_idx] == 0x02:  # kCompressedWithSnappy
+                val_idx += 1
+                decompressed = ccl_simplesnappy.decompress(io.BytesIO(buffer[val_idx:]))
+                return self.read_record_precursor(
+                    key, db_id, store_id,
+                    decompressed,
+                    bad_deserializer_data_handler, str(external_data_path))
+            else:
+                raise ValueError("Unexpected value after kRequiresProcessingSSVPseudoVersion")
+        else:
+            if blink_version >= BlinkTrailer.MIN_WIRE_FORMAT_VERSION_FOR_TRAILER:
+                trailer = BlinkTrailer.from_buffer(buffer, val_idx)  # TODO: do something with the trailer
+                val_idx += BlinkTrailer.TRAILER_SIZE
+
+            obj_raw = io.BytesIO(buffer[val_idx:])
+
+        return blink_version, obj_raw, trailer, external_data_path
+
+    def iterate_records(
+            self, db_id: int, store_id: int, *,
+            live_only=False, bad_deserializer_data_handler: typing.Callable[[IdbKey, bytes], typing.Any] = None):
+        blink_deserializer = ccl_blink_value_deserializer.BlinkV8Deserializer()
+
+        # goodness me this is a slow way of doing things
+        prefix = IndexedDb.make_prefix(db_id, store_id, 1)
+
+        for record in self._fetched_records:
+            if record.key.startswith(prefix):
+                key = IdbKey(record.key[len(prefix):])
+                if not record.value:
+                    # empty values will obviously fail, returning None is probably better than dying.
+                    yield IndexedDbRecord(self, db_id, store_id, key, None,
+                                          record.state == ccl_leveldb.KeyState.Live, record.seq, record.origin_file)
+                    continue
+                value_version, varint_raw = _le_varint_from_bytes(record.value)
+                val_idx = len(varint_raw)
+                # read the blink envelope
+                precursor = self.read_record_precursor(
+                    key, db_id, store_id, record.value[val_idx:], bad_deserializer_data_handler)
+                if precursor is None:
+                    continue  # only returns None on error, handled in the function if bad_deserializer_data_handler can
+
+                blink_version, obj_raw, trailer, external_path = precursor
+
+                try:
+                    deserializer = ccl_v8_value_deserializer.Deserializer(
+                        obj_raw, host_object_delegate=blink_deserializer.read)
+                    value = deserializer.read()
+                except Exception:
+                    if bad_deserializer_data_handler is not None:
+                        bad_deserializer_data_handler(key, record.value)
+                        continue
+                    raise
+                yield IndexedDbRecord(self, db_id, store_id, key, value,
+                                      record.state == ccl_leveldb.KeyState.Live,
+                                      record.seq, record.origin_file, external_path)
+
+    def get_blob_info(self, db_id: int, store_id: int, raw_key: bytes, file_index: int) -> IndexedDBExternalObject:
+        # if db_id > 0x7f or store_id > 0x7f:
+        #     raise NotImplementedError("there could be this many dbs, but I don't support it yet")
+
+        if result := self._blob_lookup_cache.get((db_id, store_id, raw_key, file_index)):
+            return result
+
+        # goodness me this is a slow way of doing things,
+        # TODO: we should at least cache along the way to our record
+        # prefix = bytes([0, db_id, store_id, 3])
+        prefix = IndexedDb.make_prefix(db_id, store_id, 3)
+        for record in self._fetched_records:
+            if record.user_key.startswith(prefix):
+                this_raw_key = record.user_key[len(prefix):]
+                buff = io.BytesIO(record.value)
+                idx = 0
+                while buff.tell() < len(record.value):
+                    blob_info = IndexedDBExternalObject.from_stream(buff)
+                    self._blob_lookup_cache[(db_id, store_id, this_raw_key, idx)] = blob_info
+                    idx += 1
+                # if this_raw_key == raw_key:
+                #     break
+
+        if result := self._blob_lookup_cache.get((db_id, store_id, raw_key, file_index)):
+            return result
+        else:
+            raise KeyError((db_id, store_id, raw_key, file_index))
+
+    def get_blob(self, db_id: int, store_id: int, raw_key: bytes, file_index: int) -> typing.BinaryIO:
+        # Some detail here: https://github.com/chromium/chromium/blob/master/content/browser/indexed_db/docs/README.md
+        if self._blob_dir is None:
+            raise ValueError("Can't resolve blob if blob dir is not set")
+        info = self.get_blob_info(db_id, store_id, raw_key, file_index)
+
+        # path will be: origin.blob/database id/top 16 bits of blob number with two digits/blob number
+        # TODO: check if this is still the case on non-windows systems
+        path = pathlib.Path(self._blob_dir, f"{db_id:x}", f"{info.blob_number >> 8:02x}", f"{info.blob_number:x}")
+
+        if path.exists():
+            return path.open("rb")
+
+        raise FileNotFoundError(path)
+
+    def get_undo_task_scopes(self):
+        # https://github.com/chromium/chromium/blob/master/components/services/storage/indexed_db/scopes/leveldb_scopes_coding.cc
+
+        # Prefix will be 00 00 00 00 32 (00|01|02) (varint of scope number) 00
+        # 00 00 00 00  =  Global metadata
+        # 32           =  kScopesPrefixByte from indexed_db_leveldb_coding.cc
+        # (00|01|02)   =  one of: kGlobalMetadataByte, kScopesMetadataByte or kLogByte from leveldb_scopes_coding.h
+        # (varint of scope)
+        # 00           =  kUndoTasksByte from leveldb_scopes_coding.h
+
+        # This is a slow way of doing this:
+        prefix = bytes.fromhex("00 00 00 00 32")
+        for record in self._fetched_records:
+            if record.state != ccl_leveldb.KeyState.Live:
+                continue
+            if record.user_key.startswith(prefix):
+                # process the key first as they define what we'll do later
+                o = len(prefix)
+                metadata_byte = record.user_key[o]
+                assert metadata_byte in (0, 1, 2)  # TODO: replace with real exception
+
+                o += 1
+
+                if metadata_byte == 0:  # global meta
+                    # print(f"Global metadata:\t{record.user_key.hex(' ')}")
+                    continue  # Don't currently think I need this to do the work
+                elif metadata_byte == 1:  # scope meta
+                    # print(f"Scope metadata:\t{record.user_key.hex(' ')}")
+                    # scope_number, varint_bytes = _le_varint_from_bytes(record.user_key)
+                    # o += len(varint_bytes)
+                    continue  # Don't currently think I need this to do the work
+                elif metadata_byte == 2:  # log
+                    scope_number, varint_bytes = _le_varint_from_bytes(record.user_key)
+                    o += len(varint_bytes)
+                    undo_byte = record.key[o]
+                    if undo_byte != 0:
+                        continue
+                    o += 1
+                    # print(f"Log\t{record.user_key.hex(' ')}")
+                    undo_sequence_number, = struct.unpack(">q", record.user_key[o:o + 8])
+
+                    # Value should be a LevelDBScopesUndoTask protobuf
+                    # (indexed_db_components\indexed_db\scopes\scopes_metadata.proto).
+                    # We're looking for a "Put" protobuf (first and only tag should be a Message numbered 1, with two
+                    # bytes values numbered 1 and 2 which are the original key and value respectively.
+                    # To reduce the need for dependencies, as they are so simple, the protobuf can be decoded "manually"
+                    with io.BytesIO(record.value) as value_stream:
+                        root_tag_raw = read_le_varint(value_stream)
+                        root_number = root_tag_raw >> 3
+                        if root_tag_raw & 0x07 != 2 or root_number != 1:
+                            assert root_number in (2, 3)  # TODO: remove?
+                            continue  # I don't think I need to raise an exception here?
+                        data_length = read_le_varint(value_stream)
+                        inner_value_bytes = value_stream.read(data_length)
+                        if len(inner_value_bytes) != data_length:
+                            raise ValueError("Couldn't get all data when reading the LevelDBScopesUndoTask")
+
+                    record_key_raw = None
+                    record_value_raw = None
+                    with io.BytesIO(inner_value_bytes) as inner_value_stream:
+                        while inner_value_stream.tell() < len(inner_value_bytes) and (
+                                record_key_raw is None or record_value_raw is None):
+                            tag_raw = read_le_varint(inner_value_stream)
+                            assert tag_raw & 0x07 == 2
+                            tag_number = tag_raw >> 3
+                            data_length = read_le_varint(inner_value_stream)
+                            data = inner_value_stream.read(data_length)
+                            if len(data) != data_length:
+                                raise ValueError("Couldn't get enough from the protobuf in LevelDBScopesUndoTask")
+                            if tag_number == 1:
+                                record_key_raw = data
+                            elif tag_number == 2:
+                                record_value_raw = data
+                            else:
+                                raise ValueError("Unexpected message in LevelDBScopesUndoTask")
+
+                    if not record_value_raw:
+                        continue  # I don't think we need to go further here
+
+                    with io.BytesIO(record_key_raw) as record_key_stream:
+                        db_id, object_store, index_id, length = IndexedDb.read_prefix(record_key_stream)
+                        if db_id < 1 or object_store < 1 or index_id < 1:
+                            continue  # only work with indexeddb record records
+
+                        key = IdbKey(record_key_stream.read())
+
+                        yield key, record_value_raw
+
+    def close(self):
+        self._db.close()
+
+    @property
+    def database_path(self):
+        return self._db.in_dir_path
+
+    def __enter__(self) -> "IndexedDb":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+class WrappedObjectStore:
+    """
+    A wrapper class around a "raw" IndexedDb which simplifies accessing records related to an object store. Usually only
+    created by a WrappedDatabase.
+    """
+    def __init__(self, raw_db: IndexedDb,  dbid_no: int, obj_store_id: int):
+        self._raw_db = raw_db
+        self._dbid_no = dbid_no
+        self._obj_store_id = obj_store_id
+
+    @property
+    def object_store_id(self) -> int:
+        return self._obj_store_id
+
+    @property
+    def name(self) -> str:
+        return self._raw_db.get_object_store_metadata(
+            self._dbid_no, self._obj_store_id, ObjectStoreMetadataType.StoreName)
+
+    @staticmethod
+    def _log_error(key: IdbKey, data: bytes):
+        sys.stderr.write(f"ERROR decoding key: {key}\n")
+
+    def get_blob(self, raw_key: bytes, file_index: int) -> typing.BinaryIO:
+        """
+        Deprecated: use IndexedDbRecord.get_blob_stream
+
+        :param raw_key: raw key of the record from which the blob originates
+        :param file_index: the file/blob index from a ccl_blink_value_deserializer.BlobIndex
+        :return: a file-like object of the blob
+        """
+
+        return self._raw_db.get_blob(self._dbid_no, self.object_store_id, raw_key, file_index)
+
+    # def __iter__(self):
+    #     yield from self._raw_db.iterate_records(self._dbid_no, self._obj_store_id)
+
+    def iterate_records(
+            self, *, live_only=False, errors_to_stdout=False,
+            bad_deserializer_data_handler: typing.Callable[[IdbKey, bytes], typing.Any] = None):
+
+        def _handler(key, record):
+            if bad_deserializer_data_handler is not None:
+                bad_deserializer_data_handler(key, record)
+            if errors_to_stdout:
+                WrappedObjectStore._log_error(key, record)
+
+        handler = _handler if errors_to_stdout or bad_deserializer_data_handler is not None else None
+
+        yield from self._raw_db.iterate_records(
+            self._dbid_no, self._obj_store_id, live_only=live_only,
+            bad_deserializer_data_handler=handler)
+
+    def __repr__(self):
+        return f"<WrappedObjectStore: object_store_id={self.object_store_id}; name={self.name}>"
+
+
+class WrappedDatabase:
+    """
+    A wrapper class around the raw "IndexedDb" class which simplifies access to a Database in the IndexedDb. Usually
+    only created by WrappedIndexedDb.
+    """
+    def __init__(self, raw_db: IndexedDb,  dbid: DatabaseId):
+        self._raw_db = raw_db
+        self._dbid = dbid
+
+        names = []
+        for obj_store_id in range(1, self.object_store_count + 1):
+            names.append(self._raw_db.get_object_store_metadata(
+                self.db_number, obj_store_id, ObjectStoreMetadataType.StoreName))
+        self._obj_store_names = tuple(names)
+        # pre-compile object store wrappers as there's little overhead
+        self._obj_stores = tuple(
+            WrappedObjectStore(
+                self._raw_db, self.db_number, i) for i in range(1, self.object_store_count + 1))
+
+    @property
+    def name(self) -> str:
+        """
+        :return: the name of this WrappedDatabase
+        """
+        return self._dbid.name
+
+    @property
+    def origin(self) -> str:
+        """
+        :return: the origin (host name) for this WrappedDatabase
+        """
+        return self._dbid.origin
+
+    @property
+    def db_number(self) -> int:
+        """
+        :return: the numerical ID assigned to this WrappedDatabase
+        """
+        return self._dbid.dbid_no
+
+    @property
+    def object_store_count(self) -> int:
+        """
+        :return: the "MaximumObjectStoreId" value fot this database; NB this may not be the *actual* number of object
+            stores which can be read - it is possible that some object stores may be deleted. Use len() to check the
+            number of object stores you can actually access
+        """
+        # NB obj store ids are enumerated from 1.
+        return self._raw_db.get_database_metadata(
+            self.db_number,
+            DatabaseMetadataType.MaximumObjectStoreId) or 0  # returns None if there are none.
+
+    @property
+    def object_store_names(self) -> typing.Iterable[str]:
+        """
+        :return: yields the names of the object stores in this WrappedDatabase
+        """
+        yield from self._obj_store_names
+
+    def get_object_store_by_id(self, obj_store_id: int) -> WrappedObjectStore:
+        """
+        :param obj_store_id: the numerical ID for an object store in this WrappedDatabase
+        :return: the WrappedObjectStore with the ID provided
+        """
+        if obj_store_id > 0 and obj_store_id <= self.object_store_count:
+            return self._obj_stores[obj_store_id - 1]
+        raise ValueError("obj_store_id must be greater than zero and less or equal to object_store_count "
+                         "NB object stores are enumerated from 1 - there is no store with id 0")
+
+    def get_object_store_by_name(self, name: str) -> WrappedObjectStore:
+        """
+        :param name: the name of an object store in this WrappedDatabase
+        :return: the WrappedObjectStore with the name provided
+        """
+        if name in self:
+            return self.get_object_store_by_id(self._obj_store_names.index(name) + 1)
+        raise KeyError(f"{name} is not an object store in this database")
+
+    def __iter__(self) -> typing.Iterable[WrappedObjectStore]:
+        """
+        :return: yields the object stores in this WrappedDatabase
+        """
+        yield from self._obj_stores
+
+    def __len__(self) -> int:
+        """
+        :return: the number of object stores accessible in this WrappedDatabase
+        """
+        return len(self._obj_stores)
+
+    def __contains__(self, item: str) -> bool:
+        """
+        :param item: the name of an object store in this WrappedDatabase
+        :return: True if the name provided matches one of the Object stores in this WrappedDatabase
+        """
+        return item in self._obj_store_names
+
+    def __getitem__(self, item: typing.Union[int, str]) -> WrappedObjectStore:
+        """
+        :param item: either the numerical ID of an object store (as an int) or the name of an object store in this
+            WrappedDatabase
+        :return:
+        """
+        if isinstance(item, int):
+            return self.get_object_store_by_id(item)
+        elif isinstance(item, str):
+            return self.get_object_store_by_name(item)
+        raise TypeError("Key can only be str (name) or int (id number)")
+
+    def __repr__(self):
+        return f"<WrappedDatabase: id={self.db_number}; name={self.name}; origin={self.origin}>"
+
+
+class WrappedIndexDB:
+    """
+    A wrapper object around the "raw" IndexedDb class. This should be used in most cases as the code required to use it
+    is simpler and more pythonic.
+    """
+    def __init__(self, leveldb_dir: os.PathLike, leveldb_blob_dir: os.PathLike = None):
+        self._raw_db = IndexedDb(leveldb_dir, leveldb_blob_dir)
+        self._multiple_origins = len(set(x.origin for x in self._raw_db.global_metadata.db_ids)) > 1
+
+        self._db_number_lookup = {
+            x.dbid_no: WrappedDatabase(self._raw_db, x)
+            for x in self._raw_db.global_metadata.db_ids}
+        # set origin to 0 if there's only 1, and we'll ignore it in all lookups
+        self._db_name_lookup = {
+            (x.name, x.origin if self.has_multiple_origins else 0): x
+            for x in self._db_number_lookup.values()}
+
+    def close(self):
+        self._raw_db.close()
+
+    @property
+    def database_count(self) -> int:
+        """
+        :return: The number of databases in this IndexedDB
+        """
+        return len(self._db_number_lookup)
+
+    @property
+    def database_ids(self) -> typing.Iterable[DatabaseId]:
+        """
+        :return: yields DatabaseId objects which define the databases in this IndexedDb
+        """
+        yield from self._raw_db.global_metadata.db_ids
+
+    @property
+    def has_multiple_origins(self) -> bool:
+        return self._multiple_origins
+
+    def __len__(self):
+        """
+        :return: the number of databases in this IndexedDb
+        """
+        len(self._db_number_lookup)
+
+    def __contains__(self, item: typing.Union[str, int, tuple[str, str]]):
+        """
+        :param item: either a database id number, the name of a database (as a string), or (if the database has multiple
+            origins), a tuple of database name and origin
+        :return: True if this IndexedDb contains the referenced database identifier
+        """
+        if isinstance(item, str):
+            if self.has_multiple_origins:
+                raise ValueError(
+                    "Database contains multiple origins, lookups must be provided as a tuple of (name, origin)")
+            return (item, 0) in self._db_name_lookup
+        elif isinstance(item, tuple) and len(item) == 2:
+            name, origin = item
+            if not self.has_multiple_origins:
+                origin = 0  # origin ignored if not needed
+            return (name, origin) in self._db_name_lookup
+        elif isinstance(item, int):
+            return item in self._db_number_lookup
+        elif isinstance(item, DatabaseId):
+            hit = self._db_number_lookup.get(item.dbid_no)
+            return hit is not None and hit.name == item.name and hit.origin == item.origin
+        else:
+            raise TypeError("keys must be provided as a tuple of (name, origin) or a str (if only single origin) or int")
+
+    def __getitem__(self, item: typing.Union[DatabaseId, int, str, typing.Tuple[str, str]]) -> WrappedDatabase:
+        """
+        :param item: either a DatabaseID object database id number, the name of a database (as a string), or
+        (if the database has multiple origins), a tuple of database name and origin
+        :return: the WrappedDatabase referenced by the id in item
+        """
+        if isinstance(item, DatabaseId):
+            if item.dbid_no in self._db_number_lookup:
+                result = self._db_number_lookup[item.dbid_no]
+                if result.name == item.name and result.origin == item.origin:
+                    return result
+                else:
+                    raise KeyError(item)
+            else:
+                raise KeyError(item)
+        if isinstance(item, int):
+            if item in self._db_number_lookup:
+                return self._db_number_lookup[item]
+            else:
+                raise KeyError(item)
+        elif isinstance(item, str):
+            if self.has_multiple_origins:
+                raise ValueError(
+                    "Database contains multiple origins, indexes must be provided as a tuple of (name, origin)")
+            if item in self:
+                return self._db_name_lookup[item, 0]
+            else:
+                raise KeyError(item)
+        elif isinstance(item, tuple) and len(item) == 2:
+            name, origin = item
+            if not self.has_multiple_origins:
+                origin = 0  # origin ignored if not needed
+            if (name, origin) in self:
+                return self._db_name_lookup[name, origin]
+            else:
+                raise KeyError(item)
+
+        raise TypeError("Lookups must be one of int, str or tuple of name and origin")
+
+    def __repr__(self):
+        return f"<WrappedIndexDB: {self._raw_db.database_path}>"
+
+    def __enter__(self) -> "WrappedIndexDB":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/scripts/ccl/ccl_structures.py
+++ b/scripts/ccl/ccl_structures.py
@@ -1,0 +1,26 @@
+# pylint: skip-file
+import typing
+
+from ccl_chromium_reader.profile_folder_protocols import ArtifactLocationProtocol
+
+
+class ArtifactLocation(ArtifactLocationProtocol):
+    def __init__(self, source_file: str, offset: typing.Optional[int], friendly_string: str):
+        self._source_file = source_file
+        self._offset = offset
+        self._friendly_string = friendly_string
+
+    @property
+    def source_file(self) -> str:
+        return self._source_file
+
+    @property
+    def offset(self) -> typing.Optional[int]:
+        return self._offset
+
+    @property
+    def friendly_string(self) -> str:
+        return self._friendly_string
+
+    def __str__(self):
+        return self._friendly_string

--- a/scripts/ccl/ccl_structures.py
+++ b/scripts/ccl/ccl_structures.py
@@ -1,7 +1,23 @@
 # pylint: skip-file
+#
+# Vendored from CCL Forensics. ArtifactLocationProtocol is defined inline here
+# rather than imported from the upstream package, so this repo carries no
+# dependency on ccl_chromium_reader being installed.
 import typing
 
-from ccl_chromium_reader.profile_folder_protocols import ArtifactLocationProtocol
+
+class ArtifactLocationProtocol(typing.Protocol):
+    @property
+    def source_file(self) -> str:
+        raise NotImplementedError()
+
+    @property
+    def offset(self) -> typing.Optional[int]:
+        raise NotImplementedError()
+
+    @property
+    def friendly_string(self) -> str:
+        raise NotImplementedError()
 
 
 class ArtifactLocation(ArtifactLocationProtocol):

--- a/scripts/ccl/ccl_v8_value_deserializer.py
+++ b/scripts/ccl/ccl_v8_value_deserializer.py
@@ -1,0 +1,631 @@
+"""
+Copyright 2020, CCL Forensics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+# Vendored from CCL Forensics. Only the package-relative imports are changed,
+# to match this repo's flat scripts/ccl layout.
+# pylint: skip-file
+
+import sys
+import struct
+import datetime
+import types
+import typing
+import re
+
+__version__ = "0.1.1"
+__description__ = "Partial reimplementation of the V8 Javascript Object Serialization"
+__contact__ = "Alex Caithness"
+
+# TODO: We need to address cyclic references, which are permissible. Probably take the same approach as in ccl_bplist
+#  and subclass the collection types to resolve references JIT
+
+# See: https://github.com/v8/v8/blob/master/src/objects/value-serializer.cc
+
+__DEBUG = False
+
+
+def log(msg, debug_only=True):
+    if not debug_only or __DEBUG:
+        caller_name = sys._getframe(1).f_code.co_name
+        caller_line = sys._getframe(1).f_code.co_firstlineno
+        print(f"{caller_name} ({caller_line}):\t{msg}")
+
+
+def read_le_varint(stream: typing.BinaryIO, is_32bit=False) -> typing.Optional[typing.Tuple[int, bytes]]:
+    # this only outputs unsigned
+    limit = 5 if is_32bit else 10
+    i = 0
+    result = 0
+    underlying_bytes = []
+    while i < limit:  # 64 bit max possible?
+        raw = stream.read(1)
+        if len(raw) < 1:
+            return None
+        tmp, = raw
+        underlying_bytes.append(tmp)
+        result |= ((tmp & 0x7f) << (i * 7))
+        if (tmp & 0x80) == 0:
+            break
+        i += 1
+    return result, bytes(underlying_bytes)
+
+
+class _Undefined:
+    def __bool__(self):
+        return False
+
+    def __eq__(self, other):
+        if isinstance(other, _Undefined):
+            return True
+        return False
+
+    def __repr__(self):
+        return "<Undefined>"
+
+    def __str__(self):
+        return "<Undefined>"
+
+
+class SharedObject:
+    def __init__(self, object_id: int):
+        self.id = object_id
+
+    def __repr__(self):
+        return f"<SharedObject; id: {self.id}>"
+
+    def __str__(self):
+        return f"<SharedObject; id: {self.id}>"
+
+
+class Constants:
+    # Constants
+    kLatestVersion = 15
+
+    # version:uint32_t (if at beginning of data, sets version > 0)
+    token_kVersion = b"\xFF"
+    # ignore
+    token_kPadding = b"\0"
+    # refTableSize:uint32_t (previously used for sanity checks; safe to ignore)
+    token_kVerifyObjectCount = b"?"
+    # Oddballs (no data).
+    token_kTheHole = b"-"
+    token_kUndefined = b"_"
+    token_kNull = b"0"
+    token_kTrue = b"T"
+    token_kFalse = b"F"
+    # Number represented as 32-bit integer, ZigZag-encoded
+    # (like sint32 in protobuf)
+    token_kInt32 = b"I"
+    # Number represented as 32-bit unsigned integer, varint-encoded
+    # (like uint32 in protobuf)
+    token_kUint32 = b"U"
+    # Number represented as a 64-bit double.
+    # Host byte order is used (N.B. this makes the format non-portable).
+    token_kDouble = b"N"
+    # BigInt. Bitfield:uint32_t, then raw digits storage.
+    token_kBigInt = b"Z"
+    # byteLength:uint32_t, then raw data
+    token_kUtf8String = b"S"
+    token_kOneByteString = b"\""
+    token_kTwoByteString = b"c"
+    # Reference to a serialized object. objectID:uint32_t
+    token_kObjectReference = b"^"
+    # Beginning of a JS object.
+    token_kBeginJSObject = b"o"
+    # End of a JS object. numProperties:uint32_t
+    token_kEndJSObject = b"{"
+    # Beginning of a sparse JS array. length:uint32_t
+    # Elements and properties are written as token_key/value pairs, like objects.
+    token_kBeginSparseJSArray = b"a"
+    # End of a sparse JS array. numProperties:uint32_t length:uint32_t
+    token_kEndSparseJSArray = b"@"
+    # Beginning of a dense JS array. length:uint32_t
+    # |length| elements, followed by properties as token_key/value pairs
+    token_kBeginDenseJSArray = b"A"
+    # End of a dense JS array. numProperties:uint32_t length:uint32_t
+    token_kEndDenseJSArray = b"$"
+    # Date. millisSinceEpoch:double
+    token_kDate = b"D"
+    # Boolean object. No data.
+    token_kTrueObject = b"y"
+    token_kFalseObject = b"x"
+    # Number object. value:double
+    token_kNumberObject = b"n"
+    # BigInt object. Bitfield:uint32_t, then raw digits storage.
+    token_kBigIntObject = b"z"
+    # String object, UTF-8 encoding. byteLength:uint32_t, then raw data.
+    token_kStringObject = b"s"
+    # Regular expression, UTF-8 encoding. byteLength:uint32_t, raw data
+    # flags:uint32_t.
+    token_kRegExp = b"R"
+    # Beginning of a JS map.
+    token_kBeginJSMap = b";"
+    # End of a JS map. length:uint32_t.
+    token_kEndJSMap = b":"
+    # Beginning of a JS set.
+    token_kBeginJSSet = b"'"
+    # End of a JS set. length:uint32_t.
+    token_kEndJSSet = b","
+    # Array buffer. byteLength:uint32_t, then raw data.
+    token_kArrayBuffer = b"B"
+    # Array buffer (transferred). transferID:uint32_t
+    token_kArrayBufferTransfer = b"t"
+    # View into an array buffer.
+    # subtag:ArrayBufferViewTag, byteOffset:uint32_t, byteLength:uint32_t
+    # For typed arrays, byteOffset and byteLength must be divisible by the size
+    # of the element.
+    # Note: token_kArrayBufferView is special, and should have an ArrayBuffer (or an
+    # ObjectReference to one) serialized just before it. This is a quirk arising
+    # from the previous stack-based implementation.
+    token_kArrayBufferView = b"V"
+    # Shared array buffer. transferID:uint32_t
+    token_kSharedArrayBuffer = b"u"
+    # A HeapObject shared across Isolates.sharedValueID: uint32_t
+    token_kSharedObject = 'p'
+    # A wasm module object transfer. next value is its index.
+    token_kWasmModuleTransfer = b"w"
+    # The delegate is responsible for processing all following data.
+    # This "escapes" to whatever wire format the delegate chooses.
+    token_kHostObject = b"\\"
+    # A transferred WebAssembly.Memory object. maximumPages:int32_t, then by
+    # SharedArrayBuffer tag and its data.
+    token_kWasmMemoryTransfer = b"m"
+    # A list of (subtag: ErrorTag, [subtag dependent data]). See ErrorTag for
+    # details.
+    token_kError = b"r"
+
+    # The following tags are reserved because they were in use in Chromium before
+    # the token_kHostObject tag was introduced in format version 13, at
+    #   v8           refs/heads/master@{#43466}
+    #   chromium/src refs/heads/master@{#453568}
+    #
+    # They must not be reused without a version check to prevent old values from
+    # starting to deserialize incorrectly. For simplicity, it's recommended to
+    # avoid them altogether.
+    #
+    # This is the set of tags that existed in SerializationTag.h at that time and
+    # still exist at the time of this writing (i.e., excluding those that were
+    # removed on the Chromium side because there should be no real user data
+    # containing them).
+    #
+    # It might be possible to also free up other tags which were never persisted
+    # (e.g. because they were used only for transfer) in the future.
+    token_kLegacyReservedMessagePort = b"M"
+    token_kLegacyReservedBlob = b"b"
+    token_kLegacyReservedBlobIndex = b"i"
+    token_kLegacyReservedFile = b"f"
+    token_kLegacyReservedFileIndex = b"e"
+    token_kLegacyReservedDOMFileSystem = b"d"
+    token_kLegacyReservedFileList = b"l"
+    token_kLegacyReservedFileListIndex = b"L"
+    token_kLegacyReservedImageData = b"#"
+    token_kLegacyReservedImageBitmap = b"g"
+    token_kLegacyReservedImageBitmapTransfer = b"G"
+    token_kLegacyReservedOffscreenCanvas = b"H"
+    token_kLegacyReservedCryptoKey = b"token_k"
+    token_kLegacyReservedRTCCertificate = b"token_k"
+
+
+class ArrayBufferViewTag:
+    tag_kInt8Array = "b"
+    tag_kUint8Array = "B"
+    tag_kUint8ClampedArray = "C"
+    tag_kInt16Array = "w"
+    tag_kUint16Array = "W"
+    tag_kInt32Array = "d"
+    tag_kUint32Array = "D"
+    tag_kFloat32Array = "f"
+    tag_kFloat64Array = "F"
+    tag_kBigInt64Array = "q"
+    tag_kBigUint64Array = "Q"
+    tag_kDataView = "?"
+
+    STRUCT_LOOKUP = types.MappingProxyType({
+        tag_kInt8Array: "b",
+        tag_kUint8Array: "B",
+        tag_kUint8ClampedArray: "B",
+        tag_kInt16Array: "h",
+        tag_kUint16Array: "H",
+        tag_kInt32Array: "i",
+        tag_kUint32Array: "I",
+        tag_kFloat32Array: "f",
+        tag_kFloat64Array: "d",
+        tag_kBigInt64Array: "q",
+        tag_kBigUint64Array: "Q",
+        tag_kDataView: "c"
+    })
+
+
+class Deserializer:
+    Undefined = _Undefined()
+
+    __ODDBALLS = {
+        Constants.token_kUndefined: Undefined,
+        Constants.token_kTheHole: Undefined,
+        Constants.token_kNull: None,
+        Constants.token_kTrue: True,
+        Constants.token_kFalse: False,
+    }
+
+    __WRAPPED_PRIMITIVES = {
+        Constants.token_kTrueObject,
+        Constants.token_kFalseObject,
+        Constants.token_kNumberObject,
+        Constants.token_kBigIntObject,
+        Constants.token_kStringObject
+    }
+
+    def __init__(self, stream: typing.BinaryIO, host_object_delegate: typing.Callable,
+                 *, is_little_endian=True, is_64bit=True):
+        self._f = stream
+        self._host_object_delegate = host_object_delegate
+        self._endian = "<" if is_little_endian else ">"
+        self._pointer_size = 8 if is_64bit else 4
+        self._next_id = 0
+        self._objects = []
+        self.version = self._read_header()
+
+    def _read_raw(self, length: int) -> bytes:
+        start = self._f.tell()
+        raw = self._f.read(length)
+        if len(raw) != length:
+            raise ValueError(f"Could not read all data at offset {start}; wanted {length}; got {len(raw)}")
+
+        return raw
+
+    def _read_le_varint(self) -> typing.Optional[typing.Tuple[int, bytes]]:
+        return read_le_varint(self._f)
+
+    def _read_zigzag(self) -> int:
+        unsigned = self._read_le_varint()[0]
+        if unsigned & 1:
+            return -(unsigned >> 1)
+        else:
+            return unsigned >> 1
+
+    def _read_unit32(self) -> int:
+        return self._read_le_varint()[0]
+
+    def _read_double(self) -> float:
+        return struct.unpack(f"{self._endian}d", self._read_raw(8))[0]
+
+    # def _read_uint32(self) -> int:
+    #     return self._read_le_varint()
+
+    # def _read_uint64(self) -> int:
+    #     return self._read_le_varint()
+
+    def _read_bigint(self) -> int:
+        size_flag = self._read_le_varint()[0]
+        is_neg = size_flag & 0x01
+        size = size_flag >> 4
+        raw = self._read_raw(size * self._pointer_size)
+
+        value = int.from_bytes(raw, "big" if self._endian == ">" else "little", signed=False)
+        if is_neg:
+            value = -value
+
+        return value
+
+    def _read_utf8_string(self) -> str:
+        length = self._read_le_varint()[0]
+        return self._read_raw(length).decode("utf8")
+
+    def _read_one_byte_string(self) -> typing.AnyStr:
+        length = self._read_le_varint()[0]
+        # I think this can be used to store raw 8-bit data, so return ascii if we can, otherwise bytes
+        raw = self._read_raw(length)  # .decode("ascii")
+        try:
+            result = raw.decode("ascii")
+        except UnicodeDecodeError:
+            result = raw
+        return result
+
+    def _read_two_byte_string(self) -> str:
+        length = self._read_le_varint()[0]
+        return self._read_raw(length).decode("utf-16-le")  # le?
+
+    def _read_string(self) -> str:
+        if self.version < 12:
+            return self._read_utf8_string()
+
+        value = self._read_object()
+        assert isinstance(value, str)
+
+        return value
+
+    def _read_object_by_reference(self) -> typing.Any:
+        ref_id = self._read_le_varint()[0]
+        return self._objects[ref_id]
+
+    def _read_tag(self) -> bytes:
+        while True:
+            t = self._f.read(1)
+            if t != Constants.token_kPadding:
+                return t
+
+    def _peek_tag(self) -> bytes:
+        start = self._f.tell()
+        tag = self._read_tag()
+        self._f.seek(start, 0)
+        return tag
+
+    def _read_date(self) -> datetime.datetime:
+        x = self._read_double()
+        result = datetime.datetime(1970, 1, 1) + datetime.timedelta(milliseconds=x)
+        self._objects.append(result)
+        return result
+
+    def _read_js_regex(self) -> typing.Pattern:
+        log(f"Reading js regex properties at {self._f.tell()}")
+        pattern = self._read_string()
+        flags = self._read_le_varint()
+
+        # TODO: Flags?
+        regex = re.compile(pattern)
+        self._objects.append(regex)
+        return regex
+
+    def _read_js_object_properties(self, end_tag) -> typing.Iterable[typing.Tuple[typing.Any, typing.Any]]:
+        log(f"Reading object properties at {self._f.tell()} with end tag: {end_tag}")
+        while True:
+            if self._peek_tag() == end_tag:
+                log(f"Object end at offset {self._f.tell()}")
+                break
+            key = self._read_object()
+            value = self._read_object()
+
+            yield key, value
+
+        assert self._read_tag() == end_tag
+
+    def _read_js_object(self) -> dict:
+        log(f"Reading js object properties at {self._f.tell()}")
+        result = {}
+        self._objects.append(result)
+        for key, value in self._read_js_object_properties(Constants.token_kEndJSObject):
+            result[key] = value
+        # while True:
+        #     if self._peek_tag() == end_tag:
+        #         log(f"Object end at offset {self._f.tell()}")
+        #         break
+        #     key = self._read_object()
+        #     value = self._read_object()
+        #     result[key] = value
+        #
+        # assert self._read_tag() == end_tag
+        property_count = self._read_le_varint()[0]
+        log(f"Actual property count: {len(result)}; stated property count: {property_count}")
+        if len(result) != property_count:
+            raise ValueError("Property count mismatch")
+
+        return result
+
+    def _read_js_sparse_array(self) -> list:
+        log(f"Reading js sparse array properties at {self._f.tell()}")
+        # TODO: implement a sparse list so that this isn't so horribly inefficient
+        length = self._read_le_varint()[0]
+        result = [None for _ in range(length)]
+        self._objects.append(result)
+
+        sparse_object = self._read_js_object_properties(Constants.token_kEndSparseJSArray)
+        prop_count = 0
+        for key, value in sparse_object:
+            i = int(key)
+            result[i] = value
+            prop_count += 1
+        expected_num_properties = self._read_le_varint()[0]
+
+        log(f"Actual property count: {prop_count}; stated property count: {expected_num_properties}")
+        if prop_count != expected_num_properties:
+            raise ValueError("Property count mismatch")
+
+        expected_length = self._read_le_varint()[0]  # TODO: should this be checked?
+
+        return result
+
+    def _read_js_dense_array(self) -> list:
+        log(f"Reading js dense array properties at {self._f.tell()}")
+        length = self._read_le_varint()[0]
+        result = [None for _ in range(length)]
+        self._objects.append(result)
+
+        for i in range(length):
+            result[i] = self._read_object()
+
+        # And then there's a sparse bit maybe?
+        sparse_object = self._read_js_object_properties(Constants.token_kEndDenseJSArray)
+        prop_count = 0
+        for key, value in sparse_object:
+            i = int(key)
+            result[i] = value
+            prop_count += 1
+
+        expected_num_properties = self._read_le_varint()[0]
+
+        log(f"Actual property count: {prop_count}; stated property count: {expected_num_properties}")
+        if prop_count != expected_num_properties:
+            raise ValueError("Property count mismatch")
+
+        expected_length = self._read_le_varint()[0]  # TODO: should this be checked?
+
+        return result
+
+    def _read_js_map(self) -> dict:
+        log(f"Reading js map at {self._f.tell()}")
+        result = {}
+        self._objects.append(result)
+        while True:
+            if self._peek_tag() == Constants.token_kEndJSMap:
+                log(f"End of map at {self._f.tell()}")
+                break
+
+            key = self._read_object()
+            value = self._read_object()
+            result[key] = value
+
+        assert self._read_tag() == Constants.token_kEndJSMap
+
+        expected_length = self._read_le_varint()[0]
+        log(f"Actual map item count: {len(result) * 2}; stated map item count: {expected_length}")
+        if expected_length != len(result) * 2:
+            raise ValueError("Map count mismatch")
+
+        return result
+
+    def _read_js_set(self) -> set:
+        log(f"Reading js set properties at {self._f.tell()}")
+        result = set()
+        self._objects.append(result)
+
+        while True:
+            if self._peek_tag() == Constants.token_kEndJSSet:
+                log(f"End of set at {self._f.tell()}")
+                break
+
+            result.add(self._read_object())
+
+        assert self._read_tag() == Constants.token_kEndJSSet
+
+        expected_length = self._read_le_varint()[0]
+        log(f"Actual set item count: {len(result)}; stated set item count: {expected_length}")
+        if expected_length != len(result):
+            raise ValueError("Set count mismatch")
+
+        return result
+
+    def _read_js_arraybuffer(self) -> bytes:
+        length = self._read_le_varint()[0]
+        raw = self._read_raw(length)
+        self._objects.append(raw)
+
+        return raw
+
+    def _wrap_js_array_buffer_view(self, raw: bytes) -> tuple:
+        if not isinstance(raw, bytes):
+            raise TypeError("Only bytes should be passed to be wrapped in a buffer view")
+
+        log(f"Wrapping in ArrayBufferView at offset {self._f.tell()}")
+
+        tag = chr(self._read_le_varint()[0])
+        byte_offset = self._read_le_varint()[0]
+        byte_length = self._read_le_varint()[0]
+
+        if byte_offset + byte_length > len(raw):
+            raise ValueError("Not enough data in the raw data to hold the defined data")
+
+        # See: https://github.com/v8/v8/blob/4d34ea98bb655295ab1f9003f6783bd509b7ccb3/src/objects/value-serializer.cc#L1967
+        if self.version >= 14:
+            flags = self._read_le_varint()[0]
+
+        log(f"ArrayBufferView: tag: {tag}; byte_offset: {byte_offset}; byte_length: {byte_length}")
+
+        fmt = ArrayBufferViewTag.STRUCT_LOOKUP[tag]
+        element_length = struct.calcsize(fmt)
+        if byte_length % element_length != 0:
+            raise ValueError(f"ArrayBufferView doesn't fit nicely: byte_length: {byte_length}; "
+                             f"element_length: {element_length}")
+
+        element_count = byte_length // element_length
+
+        return struct.unpack(f"{self._endian}{element_count}{fmt}", raw[byte_offset: byte_offset + byte_length])
+
+    def _read_host_object(self) -> typing.Any:
+        result = self._host_object_delegate(self._f)
+        self._objects.append(result)
+        return result
+
+    def _read_shared_object(self) -> SharedObject:
+        shobj_id = self._read_le_varint()[0]
+        return SharedObject(shobj_id)
+
+    def _not_implemented(self):
+        raise NotImplementedError("Todo")
+
+    def _read_object_internal(self) -> typing.Tuple[bytes, typing.Any]:
+        tag = self._read_tag()
+
+        log(f"Offset: {self._f.tell()}; Tag: {tag}")
+
+        if tag in Deserializer.__ODDBALLS:
+            return tag, Deserializer.__ODDBALLS[tag]
+
+        func = {
+            Constants.token_kTrueObject: lambda: Deserializer.__ODDBALLS[Constants.token_kTrue],
+            Constants.token_kFalseObject: lambda: Deserializer.__ODDBALLS[Constants.token_kFalse],
+            Constants.token_kNumberObject: self._read_double,
+            Constants.token_kUint32: self._read_unit32,
+            Constants.token_kInt32: self._read_zigzag,
+            Constants.token_kDouble: self._read_double,
+            Constants.token_kDate: self._read_date,
+            Constants.token_kBigInt: self._read_bigint,
+            Constants.token_kBigIntObject: self._read_bigint,
+            Constants.token_kUtf8String: self._read_utf8_string,
+            Constants.token_kOneByteString: self._read_one_byte_string,
+            Constants.token_kTwoByteString: self._read_two_byte_string,
+            Constants.token_kStringObject: self._read_string,
+            Constants.token_kRegExp: self._read_js_regex,
+            Constants.token_kObjectReference: self._read_object_by_reference,
+            Constants.token_kBeginJSObject: self._read_js_object,
+            Constants.token_kSharedObject: self._read_shared_object,
+            Constants.token_kBeginSparseJSArray: self._read_js_sparse_array,
+            Constants.token_kBeginDenseJSArray: self._read_js_dense_array,
+            Constants.token_kBeginJSMap: self._read_js_map,
+            Constants.token_kBeginJSSet: self._read_js_set,
+            Constants.token_kArrayBuffer: self._read_js_arraybuffer,
+            Constants.token_kSharedArrayBuffer: self._not_implemented,  # and probably never, as it can't be pulled from the data I think?
+            Constants.token_kArrayBufferTransfer: self._not_implemented,
+            Constants.token_kError: self._not_implemented,
+            Constants.token_kWasmModuleTransfer: self._not_implemented,
+            Constants.token_kWasmMemoryTransfer: self._not_implemented,
+            Constants.token_kHostObject: self._read_host_object,
+        }.get(tag)
+
+        if func is None:
+            raise ValueError(f"Unknown tag {tag}")
+
+        value = func()
+
+        if tag in Deserializer.__WRAPPED_PRIMITIVES:
+            self._objects.append(value)
+
+        return tag, value
+
+    def _read_object(self) -> typing.Any:
+        log(f"Read object at offset: {self._f.tell()}")
+        tag, o = self._read_object_internal()
+
+        if self._peek_tag() == Constants.token_kArrayBufferView:
+            assert self._read_tag() == Constants.token_kArrayBufferView
+            o = self._wrap_js_array_buffer_view(o)
+
+        return o
+
+    def _read_header(self) -> int:
+        tag = self._read_tag()
+        if tag != Constants.token_kVersion:
+            raise ValueError("Didn't get version tag in the header")
+        version = self._read_le_varint()[0]
+        return version
+
+    def read(self) -> typing.Any:
+        return self._read_object()


### PR DESCRIPTION
Adds two artifacts for the state the head unit's HMI applications persist to IndexedDB.

- HMI Application State: the valet mode record, the profile and phone as a key record, trailer settings and software update state. Every version of a key is kept, so the values read as a sequence.
- Vehicle Capability Values: the last value cached for each internal HMI topic, deduplicated across applications. These record what the vehicle was built with rather than what was done in it.

IndexedDB values are V8 serialized, so this vendors ccl_chromium_indexeddb with its V8 and Blink deserializers into scripts/ccl alongside the LevelDB reader already there. Scanning the raw files cannot see Snappy compressed table blocks, cannot recover the key a value belonged to, and misreads V8 values as JSON. Output was checked against ccl_chromium_reader 0.3.18 across all seven stores, 4,560 records, with identical per-store counts.

The theme store is excluded: it holds display styling, and its one record on the tested image references a blob the extraction does not contain. IndexedDB records carry no timestamp, so none is reported.