### PR TITLE
Set an explicit read-only token on three workflows

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - '**.py' # only trigger on python files
+
+permissions:
+  contents: read
+
 jobs:
   lint-changed-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -17,6 +17,9 @@ on:
       - 'vleapp.py'
       - 'vleappGUI.py'
 
+permissions:
+  contents: read
+
 jobs:
   runtime-contract:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_smoke.yml
+++ b/.github/workflows/windows_smoke.yml
@@ -12,6 +12,9 @@ on:
       - '.github/workflows/windows_smoke.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   windows-smoke:
     runs-on: windows-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the three workflows that had no permissions block, so they stop inheriting the repository default of write.

- python_lint.yml
- python_runtime_contract.yml
- windows_smoke.yml

None of the three writes anything. They check out, install requirements and run scripts. The other five workflows already declare what they need, and update_module_info.yml keeps its `contents: write` because it pushes.