### PR TITLE
Add raw disk image input for QNX6 and ext volumes

### DIFF
--- a/admin/docs/raw_image_input.md
+++ b/admin/docs/raw_image_input.md
@@ -1,0 +1,78 @@
+# Raw image input, and what it changed in core
+
+For maintainers, and for whoever ports this to the other LEAPP cores.
+
+`-t raw` takes a raw disk image and reads its QNX6 and ext2/3/4 volumes without
+mounting it and without administrator rights. Vehicle head units need it: the Ford
+Sync units are QNX6, the BMW MGU is ext4, and no filesystem type The Sleuth Kit
+supports can walk QNX6 at all, so those images were previously unreadable here.
+
+## The whole core surface
+
+Two files. Nothing existing was modified in either.
+
+**`vleapp.py`**, three edits totalling 8 lines:
+
+    choices=['fs', 'tar', 'zip', 'gz', 'file', 'raw']   # one enum entry
+    ...one sentence added to the -t help text...
+    elif extracttype == 'raw':                          # one dispatch branch
+        seeker = FileSeekerRaw(input_path, out_params.data_folder)
+
+**`scripts/search_files.py`**, one new class, 66 added lines, 0 changed:
+
+    class FileSeekerRaw(FileSeekerZip):
+
+Everything else in both pull requests is outside core: `scripts/vendor/` holds a
+verbatim copy of the reader, and `admin/scripts/check_vendored.py`, the
+`lint_changed.py` exclusion and the CI step are tooling.
+
+## Why it subclasses rather than walks
+
+The vendored reader exposes usable walkers (`Qnx6Walker`, `ExtWalker`, both with
+`listdir` / `entry` / `read_file`), so a seeker that walked the image lazily and
+staged only matched files was the obvious design and is not what this does.
+
+Deciding *which* partitions hold *which* filesystem, and which superblock
+generation is current, is not behind a callable seam in that tool; it is threaded
+through its command line flow. Reimplementing it here would copy non-trivial logic
+that then drifts from the vendored file, which is the exact failure the vendoring
+hash guard exists to catch.
+
+So `FileSeekerRaw` runs the vendored tool to produce a zip, then calls
+`FileSeekerZip.__init__` on it. Every staging, matching, disambiguation and
+timestamp decision stays on the path the zip seeker already runs on every zip
+input. The cost is an up-front extraction instead of lazy reads.
+
+**The seam to improve later** is exactly this: if the reader grows a callable
+"enumerate the volumes in this image" entry point, `FileSeekerRaw` can stop
+shelling out and stage lazily, and the class is the only thing that changes.
+
+## Porting it to another core
+
+The core part is small and generic. `FileSeekerRaw` references nothing
+VLEAPP-specific: it uses `logfunc`, `FileSeekerZip` and the vendored path, all of
+which exist or have equivalents in every core. Copying the class and the three
+`vleapp.py` edits is the whole job.
+
+What is worth deciding once, rather than five times:
+
+- **Where the vendored reader lives.** Here it is `scripts/vendor/`, resolved
+  relative to `search_files.py`. If the cores consolidate, this should be one
+  shared location, not five copies of a copy.
+- **Whether the staged zip is kept.** It goes to a temp directory and `cleanup()`
+  removes it. For a large volume the extraction is the slow part of the run, so
+  keeping it would make re-runs cheap. Deliberately not done yet, because the
+  report folder is shared and silently growing it by gigabytes is worse.
+- **Whether raw should be auto-detected** rather than selected with `-t`. The
+  reader can already tell whether an image holds anything it can read, so
+  detection is possible; it is a separate change and a shared one.
+
+## What was measured
+
+The same image was run three ways: through the vendor's own extracted file set,
+through a zip made by hand with the vendored reader, and through `-t raw`. All six
+artifacts common to the branches returned identical row counts, and two of the
+underlying stores were byte-identical by SHA-256 between the first two routes.
+
+`-t raw` found four QNX6 volumes on the test image, one more than the vendor's
+export carried extracted files for.

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -22,8 +22,12 @@ Functions:
 
 import time as timex
 import os
+import shutil
+import subprocess
+import sys
 import tarfile
 import struct
+import tempfile
 
 from pathlib import Path
 from scripts.ilapfuncs import *
@@ -499,6 +503,68 @@ class FileSeekerZip(FileSeekerBase):
 
     def cleanup(self):
         self.zip_file.close()
+
+
+class FileSeekerRaw(FileSeekerZip):
+    """Read a raw disk image by extracting its volumes to a zip first.
+
+    Vehicle head units run QNX6 and ext filesystems. Neither mounts here without
+    administrator rights, and no filesystem type The Sleuth Kit supports can walk
+    QNX6 at all, so a raw head unit image is otherwise unreadable by this tool.
+    scripts/vendor/qnxprobe.py reads both directly from the image.
+
+    Working out which partitions hold which filesystem, and which superblock
+    generation is the current one, happens inside qnxprobe's own command line flow
+    rather than behind a callable seam. Reimplementing that here would duplicate
+    logic that then drifts from the vendored copy, which is the thing vendoring
+    with a hash guard exists to prevent. So this runs the vendored tool to produce
+    a zip of the logical files and then behaves exactly like a zip input, which
+    keeps every staging and matching decision on the path the zip seeker already
+    exercises on every run.
+
+    The zip is written to a temporary directory and removed by cleanup(). An
+    examiner who wants to keep it, which is worth doing for a large image because
+    the extraction is the slow part, should run the vendored script directly:
+
+        python3 scripts/vendor/qnxprobe.py --extract volumes.zip IMAGE
+        python3 vleapp.py -t zip -i volumes.zip -o REPORT
+    """
+
+    def __init__(self, image_path, data_folder, exclude=None):
+        self._stage_dir = tempfile.mkdtemp(prefix='vleapp_raw_')
+        staged_zip = os.path.join(self._stage_dir, 'qnx_volumes.zip')
+        probe = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             'vendor', 'qnxprobe.py')
+        if not os.path.isfile(probe):
+            raise FileNotFoundError(
+                f'the vendored reader is missing: {probe}. Raw image input needs '
+                'scripts/vendor/qnxprobe.py.')
+
+        cmd = [sys.executable, probe, '--extract', staged_zip]
+        for text in (exclude or ()):
+            cmd += ['--exclude', text]
+        cmd.append(image_path)
+
+        logfunc(f'Reading volumes out of {os.path.basename(image_path)} with the '
+                f'vendored qnxprobe. This is the slow part of a raw image run.')
+        completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        for line in (completed.stdout or '').splitlines():
+            # The tool prints the partition table, every filesystem it confirmed and
+            # what it extracted. That belongs in the run log: it is the record of
+            # which volumes the rows below came from.
+            if line.strip():
+                logfunc(line.rstrip())
+        if completed.returncode != 0 or not os.path.isfile(staged_zip):
+            detail = (completed.stderr or '').strip() or 'no error text'
+            raise RuntimeError(
+                f'qnxprobe could not extract any filesystem from {image_path}. '
+                f'Exit {completed.returncode}: {detail}')
+
+        FileSeekerZip.__init__(self, staged_zip, data_folder)
+
+    def cleanup(self):
+        FileSeekerZip.cleanup(self)
+        shutil.rmtree(getattr(self, '_stage_dir', ''), ignore_errors=True)
 
 
 class FileSeekerFile(FileSeekerBase):

--- a/vleapp.py
+++ b/vleapp.py
@@ -149,11 +149,12 @@ def create_casedata(path):
 
 def main():
     parser = argparse.ArgumentParser(description='VLEAPP: Vehicle Logs, Events, and Protobuf Parser.')
-    parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'file'], required=False, action="store",
+    parser.add_argument('-t', choices=['fs', 'tar', 'zip', 'gz', 'file', 'raw'], required=False, action="store",
                         help=("Specify the input type. "
                               "'fs' for a folder containing extracted files with normal paths and names, "
                               "'tar', 'zip', or 'gz' for compressed packages containing files with normal names, "
-                              "'file' for a single file input."))
+                              "'file' for a single file input, "
+                              "'raw' for a raw disk image whose QNX6 or ext volumes are read without mounting."))
     parser.add_argument('-o', '--output_path', required=False, action="store",
                         help='Path to base output folder (this must exist)')
     parser.add_argument('-i', '--input_path', required=False, action="store", help='Path to input file/folder')
@@ -341,6 +342,9 @@ def crunch_artifacts(
 
         elif extracttype == 'zip':
             seeker = FileSeekerZip(input_path, out_params.data_folder)
+
+        elif extracttype == 'raw':
+            seeker = FileSeekerRaw(input_path, out_params.data_folder)
 
         else:
             logfunc('Error on argument -o (input type)')


### PR DESCRIPTION
Adds `-t raw`, which reads the QNX6 and ext2/3/4 volumes out of a raw disk image without mounting it. Vehicle head units need it: the Ford Sync units are QNX6, the BMW MGU is ext4, and Sleuth Kit cannot walk QNX6 at all.

Core surface is two files with nothing existing modified: one enum entry, one dispatch branch and one help sentence in `vleapp.py`, and a `FileSeekerRaw` in `search_files.py` that subclasses `FileSeekerZip`.

`admin/docs/raw_image_input.md` covers why it is shaped that way and what porting it to another core involves.

Stacked on #168, which vendors the reader.
