### PR TITLE
Show extraction progress on a raw image run

### DIFF
--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -21,6 +21,7 @@ Functions:
 """
 
 import time as timex
+import json
 import os
 import shutil
 import subprocess
@@ -505,6 +506,66 @@ class FileSeekerZip(FileSeekerBase):
         self.zip_file.close()
 
 
+def _format_duration(seconds):
+    seconds = int(max(0, seconds))
+    return f'{seconds // 3600:02d}:{seconds % 3600 // 60:02d}:{seconds % 60:02d}'
+
+
+class _RawExtractProgress:
+    """Throttled progress lines for a raw image extraction, through logfunc.
+
+    Reading the volumes out of a head unit image runs for minutes with no output
+    between "artifact started" and the first row, which reads as a hang. The
+    vendored reader emits one JSON object per line on stderr while it works; this
+    turns those into a line an examiner can read, at most every `interval`
+    seconds.
+
+    The counts are the reader's own and are exact, not estimated: it knows the
+    full entry list for a volume before it writes the first file. Percent is
+    per volume, because that is what the reader reports and what an examiner
+    watching a multi volume image wants to see move. Rate and elapsed are
+    cumulative across the run.
+
+    The line is kept short enough to fit the GUI log pane without widening it.
+    """
+
+    def __init__(self, interval=10.0, clock=None, log=None):
+        self.interval = interval
+        self.clock = clock or timex.monotonic
+        self.log = log or logfunc
+        self.started = self.clock()
+        self.last_report = self.started
+        self.done_bytes = 0          # completed volumes
+        self.volumes = 0
+
+    def update(self, event):
+        """One decoded progress object from the reader."""
+        volume = event.get('volume', '?')
+        files, total_files = event.get('files', 0), event.get('total_files', 0)
+        written, total_bytes = event.get('bytes', 0), event.get('total_bytes', 0)
+        complete = total_files and files >= total_files
+        now = self.clock()
+        if not complete and now - self.last_report < self.interval:
+            return
+        self.last_report = now
+        elapsed = now - self.started
+        overall = self.done_bytes + written
+        parts = [f'Reading volumes: {volume}',
+                 f'{files:,}/{total_files:,} files' if total_files else f'{files:,} files']
+        if total_bytes:
+            parts.append(f'{100.0 * written / total_bytes:.0f}%')
+        if elapsed > 0:
+            parts.append(f'{overall / elapsed / (1 << 20):.1f} MiB/s')
+        parts.append(f'elapsed {_format_duration(elapsed)}')
+        if total_bytes and 0 < written < total_bytes and elapsed > 0 and overall > 0:
+            remaining = (total_bytes - written) / (overall / elapsed)
+            parts.append(f'~{_format_duration(remaining)} left on this volume')
+        self.log('  ' + '  '.join(parts))
+        if complete:
+            self.done_bytes += written
+            self.volumes += 1
+
+
 class FileSeekerRaw(FileSeekerZip):
     """Read a raw disk image by extracting its volumes to a zip first.
 
@@ -540,25 +601,44 @@ class FileSeekerRaw(FileSeekerZip):
                 f'the vendored reader is missing: {probe}. Raw image input needs '
                 'scripts/vendor/qnxprobe.py.')
 
-        cmd = [sys.executable, probe, '--extract', staged_zip]
+        # -u so the reader's stdout is unbuffered and its report arrives while it
+        # works rather than in one block at the end. --progress puts machine
+        # readable progress on stderr; stderr is merged into stdout here and the
+        # two are told apart by the leading brace, which no report line has, so
+        # one stream is read and there is no second pipe to deadlock on.
+        cmd = [sys.executable, '-u', probe, '--progress', '--extract', staged_zip]
         for text in (exclude or ()):
             cmd += ['--exclude', text]
         cmd.append(image_path)
 
         logfunc(f'Reading volumes out of {os.path.basename(image_path)} with the '
                 f'vendored qnxprobe. This is the slow part of a raw image run.')
-        completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        for line in (completed.stdout or '').splitlines():
-            # The tool prints the partition table, every filesystem it confirmed and
-            # what it extracted. That belongs in the run log: it is the record of
+        progress = _RawExtractProgress()
+        tail = []
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT, text=True, bufsize=1)
+        for line in proc.stdout:
+            line = line.rstrip()
+            if not line:
+                continue
+            if line.lstrip().startswith('{'):
+                try:
+                    progress.update(json.loads(line))
+                    continue
+                except ValueError:
+                    pass    # not ours after all, fall through and log it
+            # The report names the partition table, every filesystem confirmed and
+            # what was extracted. That belongs in the run log: it is the record of
             # which volumes the rows below came from.
-            if line.strip():
-                logfunc(line.rstrip())
-        if completed.returncode != 0 or not os.path.isfile(staged_zip):
-            detail = (completed.stderr or '').strip() or 'no error text'
+            logfunc(line)
+            tail.append(line)
+            del tail[:-20]
+        proc.wait()
+        if proc.returncode != 0 or not os.path.isfile(staged_zip):
+            detail = '\n'.join(tail) or 'no output'
             raise RuntimeError(
                 f'qnxprobe could not extract any filesystem from {image_path}. '
-                f'Exit {completed.returncode}: {detail}')
+                f'Exit {proc.returncode}. Last output:\n{detail}')
 
         FileSeekerZip.__init__(self, staged_zip, data_folder)
 

--- a/scripts/vendor/qnxprobe.py
+++ b/scripts/vendor/qnxprobe.py
@@ -25,7 +25,7 @@ its fields checked for internal consistency before it is reported CONFIRMED.
 
 Read-only throughout. Never writes to the image.
 """
-import os, struct, sys, datetime, uuid, zipfile
+import os, struct, sys, datetime, json, time, uuid, zipfile
 
 QNX6_MAGIC     = 0x68191122
 BOOTBLOCK_SIZE = 0x2000
@@ -613,8 +613,52 @@ def apply_exclude(entries, exclude):
     return keep, len(entries) - len(keep)
 
 
-def extract_to_zip(zf, w, volume, entries, log):
-    """Stream each regular file into the open zipfile. Returns a tally."""
+class ProgressEmitter:
+    """Throttled machine-readable extraction progress, one JSON object per line.
+
+    Extraction of a head unit volume runs for minutes with nothing on stdout
+    until the volume finishes, which reads as a hang to anything driving this
+    as a subprocess. --progress emits to STDERR so the human report on stdout
+    is untouched and a caller can consume one stream without parsing the other.
+
+    Each line carries exact counts for the volume being written, not estimates:
+
+        {"volume": "@13168672", "files": 1234, "total_files": 1629,
+         "bytes": 123456789, "total_bytes": 297023717}
+
+    Throttled to one line per interval, plus a final line per volume so a
+    consumer always sees the completed state whatever the timing.
+    """
+
+    def __init__(self, stream=None, interval=1.0, clock=time.monotonic):
+        self.stream = stream if stream is not None else sys.stderr
+        self.interval = interval
+        self.clock = clock
+        self.last = 0.0
+
+    def __call__(self, volume, files, written, total_files, total_bytes):
+        now = self.clock()
+        done = total_files and files >= total_files
+        if not done and now - self.last < self.interval:
+            return
+        self.last = now
+        self.stream.write(json.dumps({
+            "volume": volume, "files": files, "total_files": total_files,
+            "bytes": written, "total_bytes": total_bytes,
+        }) + "\n")
+        self.stream.flush()
+
+
+def extract_to_zip(zf, w, volume, entries, log, progress=None):
+    """Stream each regular file into the open zipfile. Returns a tally.
+
+    progress, when given, is called after each file with
+    (volume, files_done, written_bytes, total_files, total_bytes). The totals
+    are exact rather than estimated: entries is already the full list for this
+    volume, so both are known before the first file is written.
+    """
+    total_files = sum(1 for _, _, size, _ in entries if size is not None)
+    total_bytes = sum(size for _, _, size, _ in entries if size is not None)
     files = written = skipped = failed = 0
     for path, ino, size, mtime in entries:
         arc = f"{volume}/{path}"
@@ -633,6 +677,8 @@ def extract_to_zip(zf, w, volume, entries, log):
         except Exception as exc:
             failed += 1
             log.append(f"        could not extract {arc}: {exc}")
+        if progress is not None:
+            progress(volume, files, written, total_files, total_bytes)
     return files, written, skipped, failed
 
 
@@ -848,7 +894,8 @@ def scan(fh, limit, size, cap=400):
 
 
 def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
-         extract=None, only=None, zf=None, do_triage=False, exclude=None):
+         extract=None, only=None, zf=None, do_triage=False, exclude=None,
+         reporter=None):
     size = os.path.getsize(path)
     print("=" * 78)
     print(path)
@@ -1070,7 +1117,7 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                     ents = collect(w, w.root)
                     ents, dropped = apply_exclude(ents, exclude)
                     log = []
-                    f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log)
+                    f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log, reporter)
                     print(f"        {f_:,} files, {human(wr)}"
                           + (f", {sk:,} symlinks or special files skipped" if sk else "")
                           + (f", {fa:,} FAILED" if fa else "")
@@ -1145,7 +1192,7 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                         ents = collect(w, w.root)
                         ents, dropped = apply_exclude(ents, exclude)
                         log = []
-                        f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log)
+                        f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log, reporter)
                         print(f"            {f_:,} files, {human(wr)}"
                               + (f", {sk:,} symlinks or special files skipped" if sk else "")
                               + (f", {fa:,} FAILED" if fa else "")
@@ -1488,7 +1535,11 @@ if __name__ == "__main__":
                     help="rank the volumes found by how much each has been "
                          "written, and flag encrypted or bulk ones, so you know "
                          "what to extract first")
-    ap.add_argument("--version", action="version", version="qnxprobe 1.3")
+    ap.add_argument("--progress", action="store_true",
+                    help="while extracting, emit one JSON progress object per line on "
+                         "stderr, for a caller driving this as a subprocess. stdout, "
+                         "the human readable report, is unchanged")
+    ap.add_argument("--version", action="version", version="qnxprobe 1.4")
     args = ap.parse_args()
 
     if args.self_test:
@@ -1503,6 +1554,7 @@ if __name__ == "__main__":
     if missing:
         sys.exit("not found: " + ", ".join(missing))
 
+    reporter = ProgressEmitter() if args.progress else None
     zf = None
     if args.extract:
         if os.path.exists(args.extract):
@@ -1514,7 +1566,8 @@ if __name__ == "__main__":
             main(p, scan_limit_mib=args.scan_limit, do_list=args.list,
              list_depth=args.depth, list_max=args.list_max,
                  extract=args.extract, only=args.only, zf=zf,
-                 do_triage=args.triage, exclude=args.exclude)
+                 do_triage=args.triage, exclude=args.exclude,
+                 reporter=reporter)
     finally:
         if zf is not None:
             zf.close()

--- a/scripts/vendor/vendored.json
+++ b/scripts/vendor/vendored.json
@@ -3,12 +3,12 @@
     {
       "path": "scripts/vendor/qnxprobe.py",
       "name": "qnxprobe",
-      "version": "1.3",
+      "version": "1.4",
       "upstream": "https://github.com/abrignoni/qnxprobe",
       "upstream_file": "qnxprobe.py",
-      "commit": "3c3259a3f89a953af156eddbd0727313ccf8281f",
-      "commit_date": "2026-08-27T02:27:13-05:00",
-      "sha256": "9f163a18db2c7b2f66cf6be09a8c6a260ead4d993f0311c56ee55945dfe0863c",
+      "commit": "903d2a6db74b4b54161a37618a36f12831c93194",
+      "commit_date": "2026-08-30T21:06:19-04:00",
+      "sha256": "5e1bad861c0eff939589c39fa408df2c001016f5cabd1a518f2afa0300207de9",
       "licence": "MIT",
       "licence_file": "scripts/vendor/LICENSE-qnxprobe",
       "note": "Copied verbatim. Fix upstream and re-vendor; edits here are reverted by the next sync."


### PR DESCRIPTION
A raw image run spent minutes between "artifact started" and the first row with nothing on screen, because the reader's output was captured and only logged after it finished. On a large volume that reads as a hang.

This streams the reader's output instead, and turns its machine readable progress into a throttled line:

```
Reading volumes: 2  1,747/6,115 files  50%  23.9 MiB/s  elapsed 00:00:11  ~00:00:11 left
```

Counts are the reader's own and exact, not estimated. Percent is by bytes within a volume, since one volume here is 11 files and a file percent would sit at 9% then finish.

Re-vendors qnxprobe at 1.4 for the progress support (abrignoni/qnxprobe#1). Row counts unchanged across seven artifacts, no database errors.
