### PR TITLE
Remove the raw and iva staging directory when a run ends

### DIFF
--- a/vleapp.py
+++ b/vleapp.py
@@ -361,151 +361,157 @@ def crunch_artifacts(
         temp_file.close()
         return False
 
-    # Now ready to run
-    logfunc(f'Info: {len(loader)} modules loaded.')
-    if profile_filename:
-        logfunc(f'Loaded profile: {profile_filename}')
-    logfunc(f'Artifact categories to parse: {len(plugins)}')
-    logfunc(f'File/Directory selected: {input_path}')
-    logfunc('\n--------------------------------------------------------------------------------------')
+    try:
+        # Now ready to run
+        logfunc(f'Info: {len(loader)} modules loaded.')
+        if profile_filename:
+            logfunc(f'Loaded profile: {profile_filename}')
+        logfunc(f'Artifact categories to parse: {len(plugins)}')
+        logfunc(f'File/Directory selected: {input_path}')
+        logfunc('\n--------------------------------------------------------------------------------------')
 
-    log = open(os.path.join(out_params.output_folder_base, '_HTML', '_Script_Logs', 'ProcessedFilesLog.html'), 'w+', encoding='utf8')
-    log.write(f'Extraction/Path selected: {input_path}<br><br>')
+        log = open(os.path.join(out_params.output_folder_base, '_HTML', '_Script_Logs', 'ProcessedFilesLog.html'), 'w+', encoding='utf8')
+        log.write(f'Extraction/Path selected: {input_path}<br><br>')
 
-    # Search for the files per the arguments
-    parsed_modules = 0
-    plugin_run_times = []
-    lava_only = False
-    artifact_search_pattern_id = 0
-    file_path_ids = set()
+        # Search for the files per the arguments
+        parsed_modules = 0
+        plugin_run_times = []
+        lava_only = False
+        artifact_search_pattern_id = 0
+        file_path_ids = set()
 
-    for plugin_number, plugin in enumerate(plugins, start=1):
-        # Timed from here, before the file search, because the search runs after the
-        # "artifact started" line is printed and is itself a place a run can sit.
-        plugin_start = perf_counter()
-        logfunc()
-        logfunc('[{}/{}] {} [{}] artifact started at {} UTC'.format(plugin_number, len(plugins),
-                                                              plugin.name, plugin.module_name,
-                                                              strftime('%H:%M:%S', gmtime())))
-        output_types = plugin.artifact_info.get('output_types', '')
-        if isinstance(plugin.search, list) or isinstance(plugin.search, tuple):
-            search_regexes = plugin.search
-        elif plugin.search is None:
-            search_regexes = plugin.search
-        else:
-            search_regexes = [plugin.search]
-        files_found = []
-        log.write(f'<b>For {plugin.name} artifact</b>')
-        if search_regexes is None:
-            log.write(f'<ul><li>No search regexes provided for {plugin.name} artifact.')
-            log.write("<ul><li><i>'_lava_artifacts.db'</i> used as source file.</li></ul></li></ul>")
-            files_found = [os.path.join(out_params.output_folder_base, '_lava_artifacts.db')]
-        else:
-            for artifact_search_regex in search_regexes:
-                artifact_search_pattern_id += 1
-                lava_insert_sqlite_artifact_search_pattern(
-                    artifact_search_pattern_id, plugin.module_name, plugin.name, artifact_search_regex)
-                pattern_already_searched = artifact_search_regex in seeker.searched
-                found = seeker.search(artifact_search_regex)
-                if not found:
-                    log.write(f'<ul><li>No file found for regex <i>{artifact_search_regex}</i></li></ul>')
-                else:
-                    log.write(f'<ul><li>{len(found)} {"files" if len(found) > 1 else "file"} for regex <i>{artifact_search_regex}</i> located at:')
-                    for pathh in found:
-                        # Strip \\?\ only for log display; file_infos is keyed with the
-                        # original long-path form on Windows.
-                        display_path = pathh[4:] if pathh.startswith('\\\\?\\') else pathh
-                        log.write(f'<ul><li>{display_path}</li></ul>')
-                        if seeker.file_infos.get(pathh):
-                            file_path_id = id(seeker.file_infos.get(pathh))
-                            if not pattern_already_searched and file_path_id not in file_path_ids:
-                                lava_insert_sqlite_file_path(file_path_id, seeker.file_infos.get(pathh).source_path)
-                                file_path_ids.add(file_path_id)
-                            lava_insert_sqlite_artifact_link_pattern_to_file(artifact_search_pattern_id, file_path_id)
-                    log.write(f'</li></ul>')
-                    files_found.extend(found)
-        if files_found:
-            if not lava_only and 'lava_only' in output_types:
-                lava_only = True
-            category_folder = os.path.join(out_params.output_folder_base, '_HTML',
-                                           sanitize_report_name(plugin.category, 'category'))
-            if not os.path.exists(category_folder):
+        for plugin_number, plugin in enumerate(plugins, start=1):
+            # Timed from here, before the file search, because the search runs after the
+            # "artifact started" line is printed and is itself a place a run can sit.
+            plugin_start = perf_counter()
+            logfunc()
+            logfunc('[{}/{}] {} [{}] artifact started at {} UTC'.format(plugin_number, len(plugins),
+                                                                  plugin.name, plugin.module_name,
+                                                                  strftime('%H:%M:%S', gmtime())))
+            output_types = plugin.artifact_info.get('output_types', '')
+            if isinstance(plugin.search, list) or isinstance(plugin.search, tuple):
+                search_regexes = plugin.search
+            elif plugin.search is None:
+                search_regexes = plugin.search
+            else:
+                search_regexes = [plugin.search]
+            files_found = []
+            log.write(f'<b>For {plugin.name} artifact</b>')
+            if search_regexes is None:
+                log.write(f'<ul><li>No search regexes provided for {plugin.name} artifact.')
+                log.write("<ul><li><i>'_lava_artifacts.db'</i> used as source file.</li></ul></li></ul>")
+                files_found = [os.path.join(out_params.output_folder_base, '_lava_artifacts.db')]
+            else:
+                for artifact_search_regex in search_regexes:
+                    artifact_search_pattern_id += 1
+                    lava_insert_sqlite_artifact_search_pattern(
+                        artifact_search_pattern_id, plugin.module_name, plugin.name, artifact_search_regex)
+                    pattern_already_searched = artifact_search_regex in seeker.searched
+                    found = seeker.search(artifact_search_regex)
+                    if not found:
+                        log.write(f'<ul><li>No file found for regex <i>{artifact_search_regex}</i></li></ul>')
+                    else:
+                        log.write(f'<ul><li>{len(found)} {"files" if len(found) > 1 else "file"} for regex <i>{artifact_search_regex}</i> located at:')
+                        for pathh in found:
+                            # Strip \\?\ only for log display; file_infos is keyed with the
+                            # original long-path form on Windows.
+                            display_path = pathh[4:] if pathh.startswith('\\\\?\\') else pathh
+                            log.write(f'<ul><li>{display_path}</li></ul>')
+                            if seeker.file_infos.get(pathh):
+                                file_path_id = id(seeker.file_infos.get(pathh))
+                                if not pattern_already_searched and file_path_id not in file_path_ids:
+                                    lava_insert_sqlite_file_path(file_path_id, seeker.file_infos.get(pathh).source_path)
+                                    file_path_ids.add(file_path_id)
+                                lava_insert_sqlite_artifact_link_pattern_to_file(artifact_search_pattern_id, file_path_id)
+                        log.write(f'</li></ul>')
+                        files_found.extend(found)
+            if files_found:
+                if not lava_only and 'lava_only' in output_types:
+                    lava_only = True
+                category_folder = os.path.join(out_params.output_folder_base, '_HTML',
+                                               sanitize_report_name(plugin.category, 'category'))
+                if not os.path.exists(category_folder):
+                    try:
+                        os.makedirs(category_folder)
+                    except (FileExistsError, FileNotFoundError) as ex:
+                        logfunc('Error creating {} report directory at path {}'.format(plugin.name, category_folder))
+                        logfunc('Error was {}'.format(str(ex)))
+                        lava_add_module(plugin.module_name, "Error", len(files_found), plugin.name)
+                        continue  # cannot do work
                 try:
-                    os.makedirs(category_folder)
-                except (FileExistsError, FileNotFoundError) as ex:
-                    logfunc('Error creating {} report directory at path {}'.format(plugin.name, category_folder))
+                    plugin.method(files_found, category_folder, seeker, wrap_text)
+                except Exception as ex:
+                    logfunc('Reading {} artifact had errors!'.format(plugin.name))
                     logfunc('Error was {}'.format(str(ex)))
+                    logfunc('Exception Traceback: {}'.format(traceback.format_exc()))
+                    plugin_elapsed = perf_counter() - plugin_start
+                    plugin_run_times.append((plugin.name, plugin_elapsed))
+                    logfunc('{} [{}] artifact failed after {:.1f}s'.format(
+                        plugin.name, plugin.module_name, plugin_elapsed))
                     lava_add_module(plugin.module_name, "Error", len(files_found), plugin.name)
-                    continue  # cannot do work
-            try:
-                plugin.method(files_found, category_folder, seeker, wrap_text)
-            except Exception as ex:
-                logfunc('Reading {} artifact had errors!'.format(plugin.name))
-                logfunc('Error was {}'.format(str(ex)))
-                logfunc('Exception Traceback: {}'.format(traceback.format_exc()))
-                plugin_elapsed = perf_counter() - plugin_start
-                plugin_run_times.append((plugin.name, plugin_elapsed))
-                logfunc('{} [{}] artifact failed after {:.1f}s'.format(
-                    plugin.name, plugin.module_name, plugin_elapsed))
-                lava_add_module(plugin.module_name, "Error", len(files_found), plugin.name)
-                continue  # nope
-            lava_add_module(plugin.module_name, "Complete", len(files_found), plugin.name)
-        else:
-            lava_add_module(plugin.module_name, "No files found", 0, plugin.name)
-            logfunc(f"No file found")
-        plugin_elapsed = perf_counter() - plugin_start
-        plugin_run_times.append((plugin.name, plugin_elapsed))
-        logfunc('{} [{}] artifact completed in {:.1f}s'.format(
-            plugin.name, plugin.module_name, plugin_elapsed))
-        parsed_modules += 1
-        GuiWindow.SetProgressBar(parsed_modules, len(plugins))
-        log.flush()
-    log.close()
+                    continue  # nope
+                lava_add_module(plugin.module_name, "Complete", len(files_found), plugin.name)
+            else:
+                lava_add_module(plugin.module_name, "No files found", 0, plugin.name)
+                logfunc(f"No file found")
+            plugin_elapsed = perf_counter() - plugin_start
+            plugin_run_times.append((plugin.name, plugin_elapsed))
+            logfunc('{} [{}] artifact completed in {:.1f}s'.format(
+                plugin.name, plugin.module_name, plugin_elapsed))
+            parsed_modules += 1
+            GuiWindow.SetProgressBar(parsed_modules, len(plugins))
+            log.flush()
+        log.close()
 
-    write_device_info()
-    if lava_only:
-        write_lava_only_log()
-    logfunc('')
-    logfunc('Processes completed.')
-    end = process_time()
-    end_wall = perf_counter()
-    run_time_secs =  end - start
-    run_time_HMS = strftime('%H:%M:%S', gmtime(run_time_secs))
-    logfunc("Processing time (CPU) = {}".format(run_time_HMS))
-    run_time_secs =  end_wall - start_wall
-    run_time_HMS = strftime('%H:%M:%S', gmtime(run_time_secs))
-    logfunc("Run time (wall clock) = {}".format(run_time_HMS))
-
-    # Filtered on the rounded value so the list holds exactly what the per-artifact
-    # lines showed as 1.0s or more, with no artifact visible above the cut but missing here.
-    slowest = sorted((entry for entry in plugin_run_times if round(entry[1], 1) >= 1.0),
-                     key=lambda item: item[1], reverse=True)[:SLOWEST_ARTIFACTS_TO_REPORT]
-    if slowest:
+        write_device_info()
+        if lava_only:
+            write_lava_only_log()
         logfunc('')
-        logfunc('Slowest artifacts:')
-        for artifact_name, elapsed in slowest:
-            logfunc('  {:>8.1f}s  {}'.format(elapsed, artifact_name))
+        logfunc('Processes completed.')
+        end = process_time()
+        end_wall = perf_counter()
+        run_time_secs =  end - start
+        run_time_HMS = strftime('%H:%M:%S', gmtime(run_time_secs))
+        logfunc("Processing time (CPU) = {}".format(run_time_HMS))
+        run_time_secs =  end_wall - start_wall
+        run_time_HMS = strftime('%H:%M:%S', gmtime(run_time_secs))
+        logfunc("Run time (wall clock) = {}".format(run_time_HMS))
 
-    logfunc('')
-    logfunc('Report generation started.')
-    # remove the \\?\ prefix we added to input and output paths, so it does not reflect in report
-    if is_platform_windows():
-        if out_params.output_folder_base.startswith('\\\\?\\'):
-            out_params.output_folder_base = out_params.output_folder_base[4:]
-        if input_path.startswith('\\\\?\\'):
-            input_path = input_path[4:]
+        # Filtered on the rounded value so the list holds exactly what the per-artifact
+        # lines showed as 1.0s or more, with no artifact visible above the cut but missing here.
+        slowest = sorted((entry for entry in plugin_run_times if round(entry[1], 1) >= 1.0),
+                         key=lambda item: item[1], reverse=True)[:SLOWEST_ARTIFACTS_TO_REPORT]
+        if slowest:
+            logfunc('')
+            logfunc('Slowest artifacts:')
+            for artifact_name, elapsed in slowest:
+                logfunc('  {:>8.1f}s  {}'.format(elapsed, artifact_name))
 
-    report.generate_report(out_params.output_folder_base, run_time_secs, run_time_HMS, extracttype, input_path, casedata, profile_filename, icons, lava_only)
-    logfunc('Report generation Completed.')
+        logfunc('')
+        logfunc('Report generation started.')
+        # remove the \\?\ prefix we added to input and output paths, so it does not reflect in report
+        if is_platform_windows():
+            if out_params.output_folder_base.startswith('\\\\?\\'):
+                out_params.output_folder_base = out_params.output_folder_base[4:]
+            if input_path.startswith('\\\\?\\'):
+                input_path = input_path[4:]
 
-    # Record the run in history
-    lava_project_path = os.path.join(out_params.output_folder_base, lava_json_name)
-    history.record_recent_run("vleapp", vleapp_version, lava_project_path)
+        report.generate_report(out_params.output_folder_base, run_time_secs, run_time_HMS, extracttype, input_path, casedata, profile_filename, icons, lava_only)
+        logfunc('Report generation Completed.')
 
-    logfunc('')
-    logfunc(f'Report location: {out_params.output_folder_base}')
+        # Record the run in history
+        lava_project_path = os.path.join(out_params.output_folder_base, lava_json_name)
+        history.record_recent_run("vleapp", vleapp_version, lava_project_path)
 
-    return True
+        logfunc('')
+        logfunc(f'Report location: {out_params.output_folder_base}')
+
+        return True
+    finally:
+        # FileSeekerRaw/FileSeekerIva unwrap the image into a staging directory
+        # that can be gigabytes; cleanup() removes it. Nothing else does, so run
+        # it on every exit path, not just the success return.
+        seeker.cleanup()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
`crunch_artifacts` never called `seeker.cleanup()`, so a raw or iVe run left its staging directory behind every time, including clean runs. That directory holds the volumes qnxprobe unwraps from the image and is often gigabytes, so a handful of runs leave tens of GiB in the system temp.

Wraps the run body in `try/finally` so `seeker.cleanup()` runs on every exit path. Only `FileSeekerRaw` and `FileSeekerIva` remove a directory; for zip, tar, dir and file inputs `cleanup()` just closes a handle, so nothing changes there. The large diff is almost all re-indentation from the wrap, and `git diff -w` shows only the added `try` and `finally`.

Verified against an ETFS image: no staging directory is left with the fix and one is left without it, the report completes either way, and the test suite passes.
