### PR TITLE
Remove the raw/iva staging directory when a build fails or is interrupted

### DIFF
--- a/admin/test/scripts/test_raw_seeker_init_cleanup.py
+++ b/admin/test/scripts/test_raw_seeker_init_cleanup.py
@@ -1,0 +1,83 @@
+"""Pin that a raw or iVa seeker whose __init__ fails after mkdtemp removes its
+staging directory instead of orphaning it.
+
+FileSeekerRaw and FileSeekerIva create a staging directory (tempfile.mkdtemp) as
+their first action, then extract the image into it. If that extraction raises or
+is interrupted (Ctrl-C on a slow run), __init__ never binds an object, so the
+seeker's cleanup() can never reach the staging directory. Each __init__ therefore
+removes it in a finally when the build does not complete; a build that succeeds
+keeps the directory for cleanup() to remove at end of run.
+
+The test patches mkdtemp to record the exact directory a build creates, so the
+assertion is about that directory rather than the shared temp folder, and a
+concurrent seeker on the same machine cannot make it pass or fail by accident.
+"""
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.search_files  # pylint: disable=wrong-import-position
+from scripts.search_files import FileSeekerIva, FileSeekerRaw  # pylint: disable=wrong-import-position
+
+
+class TestStagingDirCleanupOnInitFailure(unittest.TestCase):
+    """A staging directory must not outlive a failed or interrupted seeker build."""
+
+    def setUp(self):
+        self.data_folder = tempfile.mkdtemp(prefix='vleapp_test_data_')
+        self.created = []
+        real_mkdtemp = tempfile.mkdtemp
+
+        def recording_mkdtemp(*args, **kwargs):
+            path = real_mkdtemp(*args, **kwargs)
+            self.created.append(path)
+            return path
+
+        patcher = mock.patch.object(scripts.search_files.tempfile, 'mkdtemp',
+                                    side_effect=recording_mkdtemp)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def tearDown(self):
+        for path in self.created:
+            shutil.rmtree(path, ignore_errors=True)
+        shutil.rmtree(self.data_folder, ignore_errors=True)
+
+    def _assert_staging_removed(self):
+        self.assertEqual(len(self.created), 1,
+                         'expected the build to create exactly one staging directory')
+        self.assertFalse(os.path.exists(self.created[0]),
+                         'the staging directory was left behind after a failed build')
+
+    def test_raw_extraction_error_removes_staging_dir(self):
+        with mock.patch.object(scripts.search_files, '_extract_image_volumes',
+                               side_effect=RuntimeError('extraction failed')):
+            with self.assertRaises(RuntimeError):
+                FileSeekerRaw('/nonexistent/image.img', self.data_folder)
+        self._assert_staging_removed()
+
+    def test_raw_keyboard_interrupt_removes_staging_dir(self):
+        with mock.patch.object(scripts.search_files, '_extract_image_volumes',
+                               side_effect=KeyboardInterrupt()):
+            with self.assertRaises(KeyboardInterrupt):
+                FileSeekerRaw('/nonexistent/image.img', self.data_folder)
+        self._assert_staging_removed()
+
+    def test_iva_bad_archive_removes_staging_dir(self):
+        broken = os.path.join(self.data_folder, 'broken.iVa')
+        with open(broken, 'wb') as handle:
+            handle.write(b'not a zip archive')
+        with self.assertRaises(Exception):
+            FileSeekerIva(broken, self.data_folder)
+        self._assert_staging_removed()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -637,16 +637,25 @@ class FileSeekerRaw(FileSeekerZip):
 
     def __init__(self, image_path, data_folder, exclude=None):
         self._stage_dir = tempfile.mkdtemp(prefix='vleapp_raw_')
-        staged_zip = os.path.join(self._stage_dir, 'qnx_volumes.zip')
-        probe = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             'vendor', 'qnxprobe.py')
-        if not os.path.isfile(probe):
-            raise FileNotFoundError(
-                f'the vendored reader is missing: {probe}. Raw image input needs '
-                'scripts/vendor/qnxprobe.py.')
+        staged = False
+        try:
+            staged_zip = os.path.join(self._stage_dir, 'qnx_volumes.zip')
+            probe = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 'vendor', 'qnxprobe.py')
+            if not os.path.isfile(probe):
+                raise FileNotFoundError(
+                    f'the vendored reader is missing: {probe}. Raw image input needs '
+                    'scripts/vendor/qnxprobe.py.')
 
-        _extract_image_volumes(probe, image_path, staged_zip, exclude)
-        FileSeekerZip.__init__(self, staged_zip, data_folder)
+            _extract_image_volumes(probe, image_path, staged_zip, exclude)
+            FileSeekerZip.__init__(self, staged_zip, data_folder)
+            staged = True
+        finally:
+            # A failed or interrupted (Ctrl-C on a slow run) __init__ after mkdtemp
+            # never binds an object for cleanup() to reach, so remove the staging
+            # dir here; a successful build keeps it for cleanup() at end of run.
+            if not staged:
+                shutil.rmtree(self._stage_dir, ignore_errors=True)
 
     def cleanup(self):
         FileSeekerZip.cleanup(self)
@@ -681,72 +690,81 @@ class FileSeekerIva(FileSeekerZip):
 
     def __init__(self, iva_path, data_folder, exclude=None):
         self._stage_dir = tempfile.mkdtemp(prefix='vleapp_iva_')
-        probe = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             'vendor', 'qnxprobe.py')
-        if not os.path.isfile(probe):
-            raise FileNotFoundError(
-                f'the vendored reader is missing: {probe}. .iVa input needs '
-                'scripts/vendor/qnxprobe.py.')
+        staged = False
+        try:
+            probe = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                 'vendor', 'qnxprobe.py')
+            if not os.path.isfile(probe):
+                raise FileNotFoundError(
+                    f'the vendored reader is missing: {probe}. .iVa input needs '
+                    'scripts/vendor/qnxprobe.py.')
 
-        vehicle_json = None
-        with ZipFile(iva_path) as outer:
-            names = outer.namelist()
-            if 'Vehicle.json' in names:
-                vehicle_json = outer.read('Vehicle.json')
-            else:
-                logfunc('This .iVa carries no Vehicle.json, so no acquisition '
-                        'record will be reported for it.')
-            inner_names = [n for n in names if n.lower().endswith('.zip')]
-            if not inner_names:
-                raise RuntimeError(
-                    f'{os.path.basename(iva_path)} holds no inner zip, so it '
-                    'does not look like an iVe export.')
-            inner_path = os.path.join(self._stage_dir, 'inner.zip')
-            logfunc(f'Unpacking {os.path.basename(iva_path)}: '
-                    f'{inner_names[0]} ...')
-            with outer.open(inner_names[0]) as src, open(inner_path, 'wb') as dst:
-                copyfileobj(src, dst, 16 << 20)
-
-        with ZipFile(inner_path) as inner:
-            if self.SOURCE_FILES_MEMBER not in inner.namelist():
-                raise RuntimeError(
-                    f'{inner_names[0]} carries no {self.SOURCE_FILES_MEMBER}; '
-                    'this export does not include the vehicle source files.')
-            source_zip = os.path.join(self._stage_dir, self.SOURCE_FILES_MEMBER)
-            logfunc(f'Unpacking {self.SOURCE_FILES_MEMBER} ...')
-            with inner.open(self.SOURCE_FILES_MEMBER) as src, \
-                    open(source_zip, 'wb') as dst:
-                copyfileobj(src, dst, 16 << 20)
-        os.remove(inner_path)
-
-        with ZipFile(source_zip) as source:
-            images = [n for n in source.namelist()
-                      if n.startswith('DiskImages/')
-                      and n.lower().endswith(('.img', '.bin', '.dd', '.raw'))]
-            image_path = None
-            if images:
-                image_path = os.path.join(self._stage_dir,
-                                          os.path.basename(images[0]))
-                logfunc(f'The export carries a raw image, {images[0]}; reading '
-                        'the vehicle data from the image itself.')
-                with source.open(images[0]) as src, open(image_path, 'wb') as dst:
+            vehicle_json = None
+            with ZipFile(iva_path) as outer:
+                names = outer.namelist()
+                if 'Vehicle.json' in names:
+                    vehicle_json = outer.read('Vehicle.json')
+                else:
+                    logfunc('This .iVa carries no Vehicle.json, so no acquisition '
+                            'record will be reported for it.')
+                inner_names = [n for n in names if n.lower().endswith('.zip')]
+                if not inner_names:
+                    raise RuntimeError(
+                        f'{os.path.basename(iva_path)} holds no inner zip, so it '
+                        'does not look like an iVe export.')
+                inner_path = os.path.join(self._stage_dir, 'inner.zip')
+                logfunc(f'Unpacking {os.path.basename(iva_path)}: '
+                        f'{inner_names[0]} ...')
+                with outer.open(inner_names[0]) as src, open(inner_path, 'wb') as dst:
                     copyfileobj(src, dst, 16 << 20)
 
-        staged_zip = os.path.join(self._stage_dir, 'iva_volumes.zip')
-        if image_path is not None:
-            _extract_image_volumes(probe, image_path, staged_zip, exclude)
-            os.remove(image_path)
-            os.remove(source_zip)
-        else:
-            logfunc('The export carries no raw image; using the file set iVe '
-                    'extracted.')
-            staged_zip = source_zip
+            with ZipFile(inner_path) as inner:
+                if self.SOURCE_FILES_MEMBER not in inner.namelist():
+                    raise RuntimeError(
+                        f'{inner_names[0]} carries no {self.SOURCE_FILES_MEMBER}; '
+                        'this export does not include the vehicle source files.')
+                source_zip = os.path.join(self._stage_dir, self.SOURCE_FILES_MEMBER)
+                logfunc(f'Unpacking {self.SOURCE_FILES_MEMBER} ...')
+                with inner.open(self.SOURCE_FILES_MEMBER) as src, \
+                        open(source_zip, 'wb') as dst:
+                    copyfileobj(src, dst, 16 << 20)
+            os.remove(inner_path)
 
-        if vehicle_json is not None:
-            with ZipFile(staged_zip, 'a') as add:
-                add.writestr('Vehicle.json', vehicle_json)
+            with ZipFile(source_zip) as source:
+                images = [n for n in source.namelist()
+                          if n.startswith('DiskImages/')
+                          and n.lower().endswith(('.img', '.bin', '.dd', '.raw'))]
+                image_path = None
+                if images:
+                    image_path = os.path.join(self._stage_dir,
+                                              os.path.basename(images[0]))
+                    logfunc(f'The export carries a raw image, {images[0]}; reading '
+                            'the vehicle data from the image itself.')
+                    with source.open(images[0]) as src, open(image_path, 'wb') as dst:
+                        copyfileobj(src, dst, 16 << 20)
 
-        FileSeekerZip.__init__(self, staged_zip, data_folder)
+            staged_zip = os.path.join(self._stage_dir, 'iva_volumes.zip')
+            if image_path is not None:
+                _extract_image_volumes(probe, image_path, staged_zip, exclude)
+                os.remove(image_path)
+                os.remove(source_zip)
+            else:
+                logfunc('The export carries no raw image; using the file set iVe '
+                        'extracted.')
+                staged_zip = source_zip
+
+            if vehicle_json is not None:
+                with ZipFile(staged_zip, 'a') as add:
+                    add.writestr('Vehicle.json', vehicle_json)
+
+            FileSeekerZip.__init__(self, staged_zip, data_folder)
+            staged = True
+        finally:
+            # A failed or interrupted (Ctrl-C on a slow run) __init__ after mkdtemp
+            # never binds an object for cleanup() to reach, so remove the staging
+            # dir here; a successful build keeps it for cleanup() at end of run.
+            if not staged:
+                shutil.rmtree(self._stage_dir, ignore_errors=True)
 
     def cleanup(self):
         FileSeekerZip.cleanup(self)


### PR DESCRIPTION
`FileSeekerRaw` and `FileSeekerIva` create their staging directory with `mkdtemp` as the first thing `__init__` does, then extract the image into it. If that extraction raises, or is interrupted with Ctrl-C on a slow run, `__init__` never finishes: the seeker is never bound, so `cleanup()` can never reach the staging directory. It is orphaned in the system temp, and the end-of-run cleanup from #177 cannot help, since there is no seeker object.

Wraps each `__init__` body in `try/finally`: on any exit that is not a completed build, including `KeyboardInterrupt`, remove the staging directory; a successful build keeps it for `cleanup()` to remove at end of run. This closes the construction-failure half of the staging-dir lifecycle that #177 left open.

`test_raw_seeker_init_cleanup.py` pins all three paths (an extraction error, a Ctrl-C, and a malformed .iVa) and fails against the pre-fix code.
