### PR TITLE
fix(hyundai): end the device name at a control byte, record the validation gap

### DIFF
--- a/scripts/artifacts/hyundai_callHistory.py
+++ b/scripts/artifacts/hyundai_callHistory.py
@@ -5,10 +5,10 @@ __artifacts_v2__ = {
         "author": "Nixy Camacho, @pmpulkownik",
         "version": "0.3",
         "creation_date": "2023-06-09",
-        "last_update_date": "2026-09-02",
+        "last_update_date": "2026-09-03",
         "requirements": "none",
         "category": "Hyundai Vehicles",
-        "notes": "Extracts call logs per device and derives device Bluetooth MAC directly from the database filename (CH_{mac}.db).",
+        "notes": "Extracts call logs per device and derives device Bluetooth MAC directly from the database filename (CH_{mac}.db). Validated against a single Hyundai/Kia head unit from an extraction that could not be shared publicly, so no test fixture accompanies this artifact.",
         "paths": ('*/bluetooth/DB_BMS/CH_*.db*',),
         "output_types": "standard",
         "artifact_icon": "phone-call",
@@ -44,6 +44,13 @@ def _format_mac_from_filename(filename):
 
 
 def _present_columns(cursor, table, wanted):
+    """
+    The wanted columns this table actually carries, in the order given.
+
+    Firmware versions differ in what these tables hold, and a SELECT naming a
+    column the table lacks fails the whole statement. Selecting only what is
+    present costs the absent column rather than every call on that phone.
+    """
     try:
         cursor.execute(f'PRAGMA table_info({table})')
         present = {row[1] for row in cursor.fetchall()}

--- a/scripts/artifacts/hyundai_contacts.py
+++ b/scripts/artifacts/hyundai_contacts.py
@@ -5,10 +5,10 @@ __artifacts_v2__ = {
         "author": "Nixy Camacho, @pmpulkownik",
         "version": "0.3",
         "creation_date": "2023-06-09",
-        "last_update_date": "2026-09-02",
+        "last_update_date": "2026-09-03",
         "requirements": "none",
         "category": "Hyundai Vehicles",
-        "notes": "Extracts contacts per device and derives device Bluetooth MAC address directly from the database filename (MC_{mac}.db).",
+        "notes": "Extracts contacts per device and derives device Bluetooth MAC address directly from the database filename (MC_{mac}.db). Validated against a single Hyundai/Kia head unit from an extraction that could not be shared publicly, so no test fixture accompanies this artifact.",
         "paths": ('*/bluetooth/DB_BMS/MC_*.db*',),
         "output_types": "standard",
         "artifact_icon": "users",
@@ -41,6 +41,13 @@ def _format_mac_from_filename(filename):
 
 
 def _present_columns(cursor, table, wanted):
+    """
+    The wanted columns this table actually carries, in the order given.
+
+    Firmware versions differ in what these tables hold, and a SELECT naming a
+    column the table lacks fails the whole statement. Selecting only what is
+    present costs the absent column rather than every contact on that phone.
+    """
     try:
         cursor.execute(f'PRAGMA table_info({table})')
         present = {row[1] for row in cursor.fetchall()}

--- a/scripts/artifacts/hyundai_devices.py
+++ b/scripts/artifacts/hyundai_devices.py
@@ -5,10 +5,10 @@ __artifacts_v2__ = {
         "author": "Nixy Camacho, @pmpulkownik",
         "version": "0.3",
         "creation_date": "2023-06-09",
-        "last_update_date": "2026-09-02",
+        "last_update_date": "2026-09-03",
         "requirements": "none",
         "category": "Hyundai Vehicles",
-        "notes": "Parses binary structured records from wireless_dev_list.dat to extract paired device MAC addresses and friendly names.",
+        "notes": "Parses binary structured records from wireless_dev_list.dat to extract paired device MAC addresses and friendly names. Validated against a single Hyundai/Kia head unit from an extraction that could not be shared publicly, so no test fixture accompanies this artifact. The friendly name runs to the next control byte in the record.",
         "paths": ('*/wireless_dev_list.dat',),
         "output_types": "standard",
         "artifact_icon": "bluetooth",
@@ -18,11 +18,14 @@ __artifacts_v2__ = {
 import re
 from scripts.ilapfuncs import artifact_processor
 
-# Matches: MAC address (17 ASCII chars + null), optional repeated MAC, and the friendly name string
+# Matches: MAC address (17 ASCII chars + null), optional repeated MAC, and the friendly
+# name. The name runs to the next control byte: the record delimits it the same way it
+# delimits the MAC, so a trailing or embedded control byte ends the name rather than
+# travelling into the report.
 _RECORD_RE = re.compile(
     rb'([0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5})\x00'
     rb'(?:[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}\x00)?'
-    rb'([^\x00\r\n\t]+)'
+    rb'([^\x00-\x1f\x7f]+)'
 )
 
 
@@ -43,9 +46,9 @@ def hyundaiDevices(context):
                 mac_addr = match.group(1).decode('ascii', 'replace').upper()
                 raw_name = match.group(2)
                 try:
-                    dev_name = raw_name.decode('utf-8').strip().strip('\x00\x01\x02\x03\x04\x05')
+                    dev_name = raw_name.decode('utf-8').strip()
                 except UnicodeDecodeError:
-                    dev_name = raw_name.decode('latin-1', 'replace').strip().strip('\x00\x01\x02\x03\x04\x05')
+                    dev_name = raw_name.decode('latin-1', 'replace').strip()
 
                 if dev_name and (mac_addr, dev_name) not in data_list:
                     data_list.append((mac_addr, dev_name))


### PR DESCRIPTION
## What this changes

Follow-up to #181. Ends the `wireless_dev_list.dat` friendly-name capture at any control byte rather than stripping a fixed set from the ends, restores the docstrings explaining why `_present_columns` exists, and records in each artifact's `notes` that these were validated against an extraction that could not be shared.

## For a new or changed artifact

- [ ] Ran the tool against a real extraction and confirmed the row counts, not just that it imports.
- [ ] Ran `python admin/scripts/check_artifact_output.py <report folder>` on that report and **fixed or documented every finding**.
- [ ] Checked it against a second app data directory where the platform provides one (a second user, account, or container).
- [x] `notes`, `description` and `sample_data` say only what the data shows, and the numbers were re-derived from the finished run.

**The first three are deliberately unticked — see below.** No Hyundai extraction was available for this change; it was verified against synthetic fixtures only.

## Anything reviewers should know

**What was wrong.** #181 stripped `\x01`-`\x05` from the ends of the device friendly name. `str.strip(chars)` only reaches the ends and only covers the listed set, so two cases still put control bytes into the HTML report and the LAVA database:

- a trailing byte outside that set survived — `Trailing BEL\x07`
- an embedded byte survived anywhere — `Embed\x02ded`

**The fix.** The name capture now ends at any C0 control or DEL (`[^\x00-\x1f\x7f]+`), which makes the strip chain redundant and removes it. The record already delimits the friendly name the same way it delimits the MAC, so stopping at a control byte is consistent with how the rest of the record is parsed.

**A judgment call worth a second opinion.** This *truncates* at an embedded control byte — `Embed\x02ded` becomes `Embed`, not `Embedded`. Filtering instead of truncating is equally defensible. Truncation was chosen for consistency with the `\x00`-delimited parse, but if a genuine device name can carry an embedded control byte, the tail is silently lost. Nothing available here settles which behaviour matches the format, so this is the reviewer's call to overrule.

**Validation gap.** #181 was validated by its author against a single Hyundai/Kia head unit from an active case that could not be shared, so no fixture accompanies these artifacts. That is now stated in each artifact's `notes`, where an examiner reads it, rather than only in the PR thread. This is the route [the test-data bot offers](https://github.com/abrignoni/VLEAPP/pull/181#issuecomment-5526850705) for an unshareable extraction.

**How this was verified.** Synthetic `CH_`/`MC_` databases and a `wireless_dev_list.dat` built to the observed record shape, run through the plugin loader:

- `Trailing BEL\x07` → `Trailing BEL`, `Embed\x02ded` → `Embed`
- `Pixel 7`, `John's iPhone`, `José Galaxy` (the latin-1 fallback path) unchanged
- contacts from a database without `phone_type` still returned, with the column empty and a log line
- a directory matching `CH_*.db*` skipped rather than fatal

Locally green: `lint_changed` (0 new warnings), `check_claim_language`, `check_html_safety`, `check_report_local_paths`, `check_source_path`, `check_vendored`, `validate_sample_data`, and the plugin-loader import test.

These are synthetic fixtures encoding an assumed format, not evidence from a real head unit. They guard against regressions; they do not confirm the format is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYbci6R9C5XJ14Sxorn2T2

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYbci6R9C5XJ14Sxorn2T2)_