### PR TITLE
Refuse one segment of a split raw image and say when an image is short

### DIFF
--- a/admin/test/scripts/test_split_raw_image_guard.py
+++ b/admin/test/scripts/test_split_raw_image_guard.py
@@ -1,0 +1,153 @@
+"""Pin the guard around reading one segment of a split raw image.
+
+FTK Imager and its peers write a raw image as numbered segments (.001, .002,
+...) unless told to write one file. The first segment alone carries the
+partition table and the boot volumes, so the vendored reader identifies it
+cleanly and reads its front volumes correctly, while every volume past the cut
+reads as empty with nothing raised. Measured on a Ford Sync G4 image cut at
+1,500 MB: the boot partitions extracted in full and the 28.8 GiB storage volume
+reported 0 files, 0 B, failed 0.
+
+Three things stand between that and a report: split_image_sibling() recognises
+a numbered segment with its successor beside it, FileSeekerRaw refuses such a
+file before it stages anything, and _warn_incomplete_volumes() repeats in the
+run log what qnxprobe 1.12 records in volumes.json when the image turns out to
+be shorter than the volumes it describes.
+"""
+import json
+import os
+import pathlib
+import shutil
+import sys
+import tempfile
+import unittest
+import zipfile
+from unittest import mock
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.search_files  # pylint: disable=wrong-import-position
+from scripts.search_files import (  # pylint: disable=wrong-import-position
+    FileSeekerRaw, _warn_incomplete_volumes, split_image_sibling)
+
+
+class TestSplitImageSibling(unittest.TestCase):
+    """A numbered suffix with the next number beside it is a split image."""
+
+    def setUp(self):
+        self.folder = tempfile.mkdtemp(prefix='vleapp_test_split_')
+        self.addCleanup(shutil.rmtree, self.folder, True)
+
+    def touch(self, name):
+        path = os.path.join(self.folder, name)
+        with open(path, 'wb') as handle:
+            handle.write(b'x')
+        return path
+
+    def test_first_segment_with_its_successor(self):
+        first = self.touch('image.001')
+        second = self.touch('image.002')
+        self.assertEqual(split_image_sibling(first), second)
+
+    def test_first_segment_alone_is_an_image(self):
+        first = self.touch('image.001')
+        self.assertIsNone(split_image_sibling(first))
+
+    def test_a_gap_is_not_a_successor(self):
+        first = self.touch('image.001')
+        self.touch('image.003')
+        self.assertIsNone(split_image_sibling(first))
+
+    def test_middle_segment_is_still_a_segment(self):
+        second = self.touch('image.002')
+        third = self.touch('image.003')
+        self.assertEqual(split_image_sibling(second), third)
+
+    def test_width_is_kept_across_the_carry(self):
+        ninth = self.touch('image.009')
+        tenth = self.touch('image.010')
+        self.assertEqual(split_image_sibling(ninth), tenth)
+
+    def test_double_extension_keeps_the_stem(self):
+        first = self.touch('image.dd.001')
+        second = self.touch('image.dd.002')
+        self.assertEqual(split_image_sibling(first), second)
+
+    def test_a_conventional_extension_is_not_a_segment(self):
+        image = self.touch('image.img')
+        self.touch('image.002')
+        self.assertIsNone(split_image_sibling(image))
+
+    def test_a_bare_numbered_name_is_not_a_segment(self):
+        self.assertIsNone(split_image_sibling(self.touch('.001')))
+
+
+class TestRawSeekerRefusesASegment(unittest.TestCase):
+    """The refusal happens before anything is staged or the reader is started."""
+
+    def setUp(self):
+        self.folder = tempfile.mkdtemp(prefix='vleapp_test_split_')
+        self.addCleanup(shutil.rmtree, self.folder, True)
+
+    def test_first_segment_with_successor_raises_before_staging(self):
+        first = os.path.join(self.folder, 'image.001')
+        for name in ('image.001', 'image.002'):
+            with open(os.path.join(self.folder, name), 'wb') as handle:
+                handle.write(b'x')
+        with mock.patch.object(scripts.search_files.tempfile, 'mkdtemp') as mkdtemp, \
+                mock.patch.object(scripts.search_files, '_extract_image_volumes') as extract:
+            with self.assertRaises(ValueError) as caught:
+                FileSeekerRaw(first, self.folder)
+        self.assertIn('image.002', str(caught.exception))
+        mkdtemp.assert_not_called()
+        extract.assert_not_called()
+
+
+class TestIncompleteVolumeWarning(unittest.TestCase):
+    """What the reader recorded about a cut image reaches the run log."""
+
+    def setUp(self):
+        self.folder = tempfile.mkdtemp(prefix='vleapp_test_split_')
+        self.addCleanup(shutil.rmtree, self.folder, True)
+
+    def staged(self, manifest):
+        path = os.path.join(self.folder, 'qnx_volumes.zip')
+        with zipfile.ZipFile(path, 'w') as archive:
+            if manifest is not None:
+                archive.writestr('volumes.json', json.dumps(manifest))
+        return path
+
+    def test_incomplete_volume_is_logged_by_name(self):
+        manifest = {'written_by': 'qnxprobe 1.12', 'volumes': [
+            {'volume': 'p3_lba16384_dps_mfg', 'files': 23, 'short': 0},
+            {'volume': 'p9_lba737280_storage', 'files': 0, 'short': 0,
+             'extends_past_image_by_bytes': 29695668224},
+            {'volume': 'p6_lba81920_ifs', 'files': 700, 'short': 2},
+        ]}
+        with mock.patch.object(scripts.search_files, 'logfunc') as logfunc:
+            incomplete = _warn_incomplete_volumes(self.staged(manifest))
+        self.assertEqual([v['volume'] for v in incomplete],
+                         ['p9_lba737280_storage', 'p6_lba81920_ifs'])
+        logged = '\n'.join(str(call.args[0]) for call in logfunc.call_args_list)
+        self.assertIn('WARNING', logged)
+        self.assertIn('p9_lba737280_storage: reaches 29,695,668,224 bytes', logged)
+        self.assertIn('p6_lba81920_ifs', logged)
+        self.assertIn('2 cut short', logged)
+        self.assertNotIn('dps_mfg', logged)
+
+    def test_complete_volumes_stay_quiet(self):
+        manifest = {'written_by': 'qnxprobe 1.12', 'volumes': [
+            {'volume': 'p3_lba16384_dps_mfg', 'files': 23, 'short': 0}]}
+        with mock.patch.object(scripts.search_files, 'logfunc') as logfunc:
+            self.assertEqual(_warn_incomplete_volumes(self.staged(manifest)), [])
+        logfunc.assert_not_called()
+
+    def test_a_zip_without_a_manifest_stays_quiet(self):
+        with mock.patch.object(scripts.search_files, 'logfunc') as logfunc:
+            self.assertEqual(_warn_incomplete_volumes(self.staged(None)), [])
+        logfunc.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -607,6 +607,61 @@ def _extract_image_volumes(probe, image_path, staged_zip, exclude=None):
         raise RuntimeError(
             f'qnxprobe could not extract any filesystem from {image_path}. '
             f'Exit {proc.returncode}. Last output:\n{detail}')
+    _warn_incomplete_volumes(staged_zip)
+
+
+def _warn_incomplete_volumes(staged_zip):
+    """Say in the run log when the reader found the image shorter than its volumes.
+
+    qnxprobe 1.12 records per volume, in volumes.json, how far the volume reaches
+    past the end of the image (extends_past_image_by_bytes) and how many of its
+    files were cut by that end (short). That is the whole difference between a
+    small disk and the first segment of a split one, and it sits in a zip the
+    examiner never opens, so repeat it here, where the run log is read. Returns
+    the incomplete volumes.
+    """
+    try:
+        with ZipFile(staged_zip) as archive:
+            volumes = json.loads(archive.read('volumes.json')).get('volumes', [])
+    except (KeyError, ValueError, OSError):
+        return []
+    incomplete = [v for v in volumes
+                  if v.get('extends_past_image_by_bytes') or v.get('short')]
+    if not incomplete:
+        return []
+    logfunc('WARNING: the image is shorter than the volumes it describes. Rows from '
+            'these volumes come from an incomplete read:')
+    for volume in incomplete:
+        past = volume.get('extends_past_image_by_bytes') or 0
+        logfunc(f"  {volume.get('volume')}: reaches {past:,} bytes past the end of the "
+                f"image, {volume.get('files', 0):,} files read whole, "
+                f"{volume.get('short', 0):,} cut short")
+    logfunc('  If this is the first segment of a split image (.001 beside .002), join '
+            'the segments and run the joined file.')
+    return incomplete
+
+
+def split_image_sibling(image_path):
+    """The next segment of a split image, when this file is one segment of it.
+
+    FTK Imager and its peers write a raw image as numbered segments (.001, .002,
+    ...) unless told to write one file, and the first segment alone carries the
+    partition table and the boot volumes, so it identifies cleanly and every
+    volume past the cut reads as empty. Measured on a Ford Sync G4 image cut at
+    1,500 MB: the boot partitions extracted in full and the 28.8 GiB storage
+    volume reported 0 files with nothing raised. A numbered suffix with the next
+    number sitting beside it is that case, and the answer is to join the
+    segments, not to read the first one.
+
+    Returns the path of the next segment, or None when the suffix is not a
+    number or no next segment is beside this file.
+    """
+    stem, dot, suffix = os.path.basename(image_path).rpartition('.')
+    if not dot or not stem or not (suffix.isascii() and suffix.isdigit()):
+        return None
+    following = str(int(suffix) + 1).zfill(len(suffix))
+    candidate = os.path.join(os.path.dirname(image_path), f'{stem}.{following}')
+    return candidate if os.path.isfile(candidate) else None
 
 
 class FileSeekerRaw(FileSeekerZip):
@@ -636,6 +691,13 @@ class FileSeekerRaw(FileSeekerZip):
     """
 
     def __init__(self, image_path, data_folder, exclude=None):
+        sibling = split_image_sibling(image_path)
+        if sibling:
+            raise ValueError(
+                f'{os.path.basename(image_path)} is one segment of a split image: '
+                f'{os.path.basename(sibling)} sits beside it. Reading the first segment '
+                f'alone reports every volume past the cut as empty. Join the segments '
+                f'(cat, or copy /b on Windows) and run the joined file.')
         self._stage_dir = tempfile.mkdtemp(prefix='vleapp_raw_')
         staged = False
         try:

--- a/scripts/vendor/qnxprobe.py
+++ b/scripts/vendor/qnxprobe.py
@@ -27,7 +27,7 @@ Read-only throughout. Never writes to the image.
 """
 import os, re, struct, sys, datetime, json, time, uuid, zipfile
 
-QNXPROBE_VERSION = "1.10"
+QNXPROBE_VERSION = "1.12"
 
 QNX6_MAGIC     = 0x68191122
 BOOTBLOCK_SIZE = 0x2000
@@ -103,11 +103,41 @@ def report_generations(copies, sized_regions, how_of):
     return order, gens
 
 
+# read_at() is the only path from a walker to the image, so a short answer from
+# it is the one signal that a read reached past the end of the file. The walkers
+# pad a short block with zeros, which is right for a sector an acquisition could
+# not read and hides a cut image completely; this tally lets extract_to_zip()
+# tell the two apart, per file, without each walker having to know.
+EOF_SHORTFALL = {"bytes": 0}
+
+
 def read_at(fh, off, n):
     try:
-        fh.seek(off); return fh.read(n)
+        fh.seek(off); data = fh.read(n)
     except OSError:
         return b""
+    if len(data) < n:
+        EOF_SHORTFALL["bytes"] += n - len(data)
+    return data
+
+
+def short_regions(size, sized_regions, skip=()):
+    """Regions the partition table describes that the file does not hold in full.
+
+    Returns [(label, start, region_size, missing)] for every region whose end
+    lies past the end of the file, missing being how many of its bytes are not
+    here; missing == region_size means the region begins past the end of the
+    file. A file that holds only the first segment of a split acquisition has
+    this shape, and nothing else in a probe can tell that case from a small disk.
+    """
+    out = []
+    for label, start, rsize in sized_regions:
+        if not rsize or label in skip:
+            continue
+        end = start + rsize
+        if end > size:
+            out.append((label, start, rsize, min(rsize, end - size)))
+    return out
 
 
 def ts(v):
@@ -1738,17 +1768,30 @@ class ProgressEmitter:
         self.stream.flush()
 
 
-def extract_to_zip(zf, w, volume, entries, log, progress=None):
+def extract_to_zip(zf, w, volume, entries, log, progress=None, may_be_short=False):
     """Stream each regular file into the open zipfile. Returns a tally.
 
-    progress, when given, is called after each file with
-    (volume, files_done, written_bytes, total_files, total_bytes). The totals
-    are exact rather than estimated: entries is already the full list for this
-    volume, so both are known before the first file is written.
+    Returns (files, written, skipped, failed, short). progress, when given, is
+    called after each file with (volume, files_done, written_bytes,
+    total_files, total_bytes). The totals are exact rather than estimated:
+    entries is already the full list for this volume, so both are known before
+    the first file is written.
+
+    A file whose blocks lie past the end of the image is a SHORT read: read_at()
+    answers a seek past the end of the file with empty bytes, so the walker
+    hands back fewer bytes than the inode says and raises nothing. Such a file
+    is counted in short, not in files, and logged. With may_be_short, which the
+    caller passes when it already knows this volume reaches past the end of the
+    image, each file is spooled before it is written so a short one can be
+    stored under a name that says how much of it is here. On a volume with no
+    reason to expect it the file streams straight into the zip; a short one
+    then keeps its name, and the count and the log still say it was short.
     """
+    import shutil
+    import tempfile
     total_files = sum(1 for _, _, size, _ in entries if size is not None)
     total_bytes = sum(size for _, _, size, _ in entries if size is not None)
-    files = written = skipped = failed = 0
+    files = written = skipped = failed = short = 0
     for path, ino, size, mtime in entries:
         arc = f"{volume}/{path}"
         if size is None:
@@ -1758,17 +1801,42 @@ def extract_to_zip(zf, w, volume, entries, log, progress=None):
             info = zipfile.ZipInfo(arc, date_time=_zip_time(mtime))
             info.compress_type = zipfile.ZIP_DEFLATED
             info.external_attr = 0o100644 << 16
-            with zf.open(info, "w") as dst:
-                for chunk in w.read_file(ino, size):
-                    dst.write(chunk)
-            files += 1
-            written += size
+            got = 0
+            before = EOF_SHORTFALL["bytes"]
+            if may_be_short:
+                with tempfile.SpooledTemporaryFile(max_size=32 << 20) as spool:
+                    for chunk in w.read_file(ino, size):
+                        spool.write(chunk)
+                        got += len(chunk)
+                    got = min(got, max(size - (EOF_SHORTFALL["bytes"] - before), 0))
+                    if got < size:
+                        info.filename = f"{arc}.SHORT-{got}-of-{size}-bytes"
+                    spool.seek(0)
+                    with zf.open(info, "w") as dst:
+                        shutil.copyfileobj(spool, dst)
+            else:
+                with zf.open(info, "w") as dst:
+                    for chunk in w.read_file(ino, size):
+                        dst.write(chunk)
+                        got += len(chunk)
+                got = min(got, max(size - (EOF_SHORTFALL["bytes"] - before), 0))
+            # A walker pads a block the image ends inside with zeros, so the bytes
+            # it handed back are not the bytes that were there; the shortfall
+            # read_at() tallied while this file was read is.
+            if got < size:
+                short += 1
+                written += got
+                log.append(f"        SHORT {arc}: {got:,} of {size:,} bytes are in the "
+                           f"image, the rest lies past its end")
+            else:
+                files += 1
+                written += size
         except Exception as exc:
             failed += 1
             log.append(f"        could not extract {arc}: {exc}")
         if progress is not None:
             progress(volume, files, written, total_files, total_bytes)
-    return files, written, skipped, failed
+    return files, written, skipped, failed, short
 
 
 # ---------------------------------------------------------------------------
@@ -2268,6 +2336,42 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
             regions.append(("whole image", 0))
             vol_names[0] = volume_name(None, 0)
 
+        # A partition table describes a whole disk and the file may hold only
+        # the front of it. FTK Imager and its peers split a raw image into
+        # numbered segments (.001, .002, ...) and the first segment carries the
+        # table and the boot volumes, so it identifies cleanly and its front
+        # volumes read correctly while the volume holding the user data ends
+        # past the cut, where every read answers empty. Measured on a Ford Sync
+        # G4 image cut at 1,500 MB: the boot partitions extracted in full and
+        # the 28.8 GiB storage volume walked to 0 files with nothing raised.
+        # Say so here, before any volume is reported as empty.
+        short_by = {}                 # region start -> bytes past the end of the file
+        short = short_regions(size, sized_regions, skip=protective)
+        if short:
+            reach = max(st + rs for lab, st, rs in sized_regions if lab not in protective)
+            print("\n  IMAGE IS SHORTER THAN ITS PARTITION TABLE")
+            print(f"    the file holds {human(size)}; the partitions it describes "
+                  f"reach {human(reach)}")
+            for label, st, rs, missing in short:
+                short_by[st] = missing
+                if missing >= rs:
+                    where = "begins past the end of the file  (none of it is here)"
+                else:
+                    where = f"ends {human(missing)} past the end of the file  (partly here)"
+                print(f"    {label:<28} {where}")
+            print("    A raw image split into numbered segments (.001, .002, ...) has to be")
+            print("    joined before it is read; its first segment alone looks like this.")
+            print("    Each volume above is marked INCOMPLETE below, and a file on it that")
+            print("    reaches past the end is counted SHORT and stored under a name that")
+            print("    says how much of it is here, not as an extracted file.")
+
+        def missing_past_end(base, declared_end=None):
+            """Bytes of the volume at base that lie past the end of the file."""
+            missing = short_by.get(base, 0)
+            if declared_end is not None:
+                missing = max(missing, declared_end - size)
+            return max(missing, 0)
+
         # the two offsets the kernel itself probes, per region and whole-image
         print()
         for label, base in [("image start", 0)] + regions:
@@ -2429,7 +2533,9 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                     ents = collect(w, w.root)
                     ents, dropped = apply_exclude(ents, exclude)
                     log = []
-                    f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log, reporter)
+                    miss = missing_past_end(base, base + total)
+                    f_, wr, sk, fa, sh = extract_to_zip(zf, w, vol, ents, log, reporter,
+                                                            may_be_short=bool(miss))
                     if manifest is not None:
                         rsize = next((r[2] for r in sized_regions if r[1] == base), None)
                         manifest.append({
@@ -2441,14 +2547,19 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                             "superblock_serial": sb["serial"],
                             "files": f_, "bytes": wr,
                             "symlinks_or_special_skipped": sk,
-                            "failed": fa, "excluded": dropped,
+                            "failed": fa, "short": sh, "excluded": dropped,
                         })
                     print(f"        {f_:,} files, {human(wr)}"
                           + (f", {sk:,} symlinks or special files skipped" if sk else "")
                           + (f", {fa:,} FAILED" if fa else "")
+                          + (f", {sh:,} SHORT" if sh else "")
                           + (f", {dropped:,} excluded" if dropped else ""))
                     for line in log[:5]:
                         print(line)
+                    if miss:
+                        print(f"        INCOMPLETE: this volume reaches {human(miss)} past the end of the file")
+                        if manifest is not None:
+                            manifest[-1]["extends_past_image_by_bytes"] = miss
                 except Exception as exc:
                     print(f"        could not extract this filesystem: {exc}")
             print()
@@ -2520,7 +2631,9 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                         ents = collect(w, w.root)
                         ents, dropped = apply_exclude(ents, exclude)
                         log = []
-                        f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log, reporter)
+                        miss = missing_past_end(b)
+                        f_, wr, sk, fa, sh = extract_to_zip(zf, w, vol, ents, log, reporter,
+                                                                may_be_short=bool(miss))
                         if manifest is not None:
                             _u = read_at(fh, b + EXT_SB_OFF, 1024)
                             manifest.append({
@@ -2532,14 +2645,19 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                                 "label": ext_name,
                                 "files": f_, "bytes": wr,
                                 "symlinks_or_special_skipped": sk,
-                                "failed": fa, "excluded": dropped,
+                                "failed": fa, "short": sh, "excluded": dropped,
                             })
                         print(f"            {f_:,} files, {human(wr)}"
                               + (f", {sk:,} symlinks or special files skipped" if sk else "")
                               + (f", {fa:,} FAILED" if fa else "")
+                              + (f", {sh:,} SHORT" if sh else "")
                               + (f", {dropped:,} excluded" if dropped else ""))
                         for line in log[:5]:
                             print(line)
+                        if miss:
+                            print(f"            INCOMPLETE: this volume reaches {human(miss)} past the end of the file")
+                            if manifest is not None:
+                                manifest[-1]["extends_past_image_by_bytes"] = miss
                     except Exception as exc:
                         print(f"        could not extract: {exc}")
 
@@ -2559,7 +2677,9 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                             ents = collect(w, w.root)
                             ents, dropped = apply_exclude(ents, exclude)
                             log = []
-                            f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents, log, reporter)
+                            miss = missing_past_end(b)
+                            f_, wr, sk, fa, sh = extract_to_zip(zf, w, vol, ents, log, reporter,
+                                                                    may_be_short=bool(miss))
                             if manifest is not None:
                                 manifest.append({
                                     "volume": vol, "image": os.path.basename(path),
@@ -2567,14 +2687,19 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                                     "partition_size_bytes": sz, "filesystem": kind,
                                     "files": f_, "bytes": wr,
                                     "symlinks_or_special_skipped": sk,
-                                    "failed": fa, "excluded": dropped,
+                                    "failed": fa, "short": sh, "excluded": dropped,
                                 })
                             print(f"            {f_:,} files, {human(wr)}"
                                   + (f", {sk:,} symlinks or special files skipped" if sk else "")
                                   + (f", {fa:,} FAILED" if fa else "")
+                                  + (f", {sh:,} SHORT" if sh else "")
                                   + (f", {dropped:,} excluded" if dropped else ""))
                             for line in log[:5]:
                                 print(line)
+                            if miss:
+                                print(f"            INCOMPLETE: this volume reaches {human(miss)} past the end of the file")
+                                if manifest is not None:
+                                    manifest[-1]["extends_past_image_by_bytes"] = miss
                         except Exception as exc:
                             print(f"        could not extract: {exc}")
 
@@ -2606,8 +2731,9 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                                 ents = collect(w, w.root)
                                 ents, dropped = apply_exclude(ents, exclude)
                                 log = []
-                                f_, wr, sk, fa = extract_to_zip(zf, w, vol, ents,
-                                                                log, reporter)
+                                miss = missing_past_end(b)
+                                f_, wr, sk, fa, sh = extract_to_zip(zf, w, vol, ents, log, reporter,
+                                                                        may_be_short=bool(miss))
                                 if manifest is not None:
                                     manifest.append({
                                         "volume": vol, "image": os.path.basename(path),
@@ -2619,15 +2745,20 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                                         "image_checksum_balances": w.cksum_ok,
                                         "files": f_, "bytes": wr,
                                         "symlinks_or_special_skipped": sk,
-                                        "failed": fa, "excluded": dropped,
+                                        "failed": fa, "short": sh, "excluded": dropped,
                                     })
                                 print(f"            {f_:,} files, {human(wr)}"
                                       + (f", {sk:,} symlinks or special files skipped"
                                          if sk else "")
                                       + (f", {fa:,} FAILED" if fa else "")
+                                      + (f", {sh:,} SHORT" if sh else "")
                                       + (f", {dropped:,} excluded" if dropped else ""))
                                 for line in log[:5]:
                                     print(line)
+                                if miss:
+                                    print(f"            INCOMPLETE: this volume reaches {human(miss)} past the end of the file")
+                                    if manifest is not None:
+                                        manifest[-1]["extends_past_image_by_bytes"] = miss
                             except Exception as exc:
                                 print(f"        could not extract: {exc}")
                 print()
@@ -3205,6 +3336,73 @@ def self_test():
             ok = False
         print(f"  [{mark}] FAT, exFAT, ETFS, EFS and IFS all decline the "
               f"qnx4 image")
+
+        # A cut image. The first segment of a split acquisition (.001 of an
+        # FTK Imager raw set) carries the partition table and the boot volumes,
+        # so it identifies cleanly, and every volume past the cut reads as empty
+        # because read_at() answers a seek past the end of the file with empty
+        # bytes. Measured 2026-09-04 on a Ford Sync G4 image cut at 1,500 MB: the
+        # boot partitions extracted in full and the 28.8 GiB storage volume
+        # walked to 0 files with nothing raised. The probe has to say the file is
+        # shorter than its table, and a file whose blocks lie past the cut has to
+        # be counted SHORT and stored under a name that says so.
+        cut = os.path.join(d, "positive_le_cut.img")
+        with open(a, "rb") as src, open(cut, "wb") as dst:
+            dst.write(src.read(3 * 1024 * 1024))
+        reps = {}
+        for name, path in (("cut", cut), ("full", a)):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                main(path)
+            reps[name] = buf.getvalue()
+        after = reps["cut"].split("IMAGE IS SHORTER THAN ITS PARTITION TABLE", 1)
+        warned = len(after) == 2 and "MBR part 1" in after[1][:600]
+        quiet = "SHORTER THAN" not in reps["full"]
+        for label, cond in (
+                ("a 3 MiB cut of the 7 MiB positive image is reported shorter than "
+                 "its partition table, naming MBR part 1", warned),
+                ("the full positive image draws no such warning", quiet)):
+            if not cond:
+                ok = False
+            print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+
+        # The qnx4 fixture behind an MBR whose partition reaches past the cut.
+        # multi.bin's second extent is qnx4 block 10 (offset 4608); the image
+        # ends there, after the xblk that points to it, so the walk still finds
+        # the file and its tail is past the end.
+        mimg = bytearray(2048 * SECTOR + 4608)
+        ent = bytearray(16)
+        ent[4] = 0x4d
+        struct.pack_into("<II", ent, 8, 2048, 32)      # 16 KiB declared, 4.5 KiB here
+        mimg[446:462] = ent
+        mimg[510:512] = b"\x55\xaa"
+        mimg[2048 * SECTOR:] = q4[:4608]
+        q4cut = os.path.join(d, "qnx4_behind_mbr_cut.img")
+        open(q4cut, "wb").write(bytes(mimg))
+        q4zip = os.path.join(d, "qnx4_cut.zip")
+        man = []
+        buf = io.StringIO()
+        with zipfile.ZipFile(q4zip, "w") as zf, contextlib.redirect_stdout(buf):
+            main(q4cut, extract=q4zip, zf=zf, manifest=man)
+        rep_q4 = buf.getvalue()
+        names = zipfile.ZipFile(q4zip).namelist()
+        vol = "p1_lba2048"
+        short_named = [n for n in names
+                       if n.startswith(f"{vol}/multi.bin.SHORT-512-of-700")]
+        entry = man[0] if man else {}
+        for label, cond in (
+                ("a file reaching past the cut is counted SHORT in the report and "
+                 "the manifest, beside the 3 whole files",
+                 "1 SHORT" in rep_q4 and entry.get("short") == 1
+                 and entry.get("files") == 3
+                 and entry.get("extends_past_image_by_bytes", 0) > 0),
+                ("the short file is stored under a name saying how much of it is "
+                 "here, and the whole files keep theirs",
+                 len(short_named) == 1 and f"{vol}/selftest.txt" in names
+                 and f"{vol}/multi.bin" not in names)):
+            if not cond:
+                ok = False
+            print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
 
         print()
         print("  SELF-TEST PASSED. The detector reports positives and negatives"

--- a/scripts/vendor/vendored.json
+++ b/scripts/vendor/vendored.json
@@ -3,12 +3,12 @@
     {
       "path": "scripts/vendor/qnxprobe.py",
       "name": "qnxprobe",
-      "version": "1.10",
+      "version": "1.12",
       "upstream": "https://github.com/abrignoni/qnxprobe",
       "upstream_file": "qnxprobe.py",
-      "commit": "121c579d9bd02e6b72096ada1a6ed49a0752956c",
-      "commit_date": "2026-09-02T14:25:39-04:00",
-      "sha256": "c7c91f480b9374a3e030d33e3e4f5568f449e127bf26221407a0f1e56fe94e23",
+      "commit": "73d41840b806cc57f1b2fe480069e7285e47a60b",
+      "commit_date": "2026-09-04T19:07:39-04:00",
+      "sha256": "0a399cadbb5592d5c433b7e72eaaca17a1dfc7135ed1917449ad9676dd3a18b5",
       "licence": "MIT",
       "licence_file": "scripts/vendor/LICENSE-qnxprobe",
       "note": "Copied verbatim. Fix upstream and re-vendor; edits here are reverted by the next sync."

--- a/vleappGUI.py
+++ b/vleappGUI.py
@@ -224,6 +224,17 @@ def ValidateInput():
     elif os.path.isdir(i_path):
         ext_type = 'fs'
     else:
+        sibling = split_image_sibling(i_path)
+        if sibling:
+            tk_msgbox.showerror(
+                title='Error',
+                message=(f'{os.path.basename(i_path)} is one segment of a split image: '
+                         f'{os.path.basename(sibling)} sits beside it.\n\nReading the '
+                         'first segment alone reports every volume past the cut as '
+                         'empty. Join the segments (cat, or copy /b on Windows) and '
+                         'select the joined file.'),
+                parent=main_window)
+            return False, ext_type, None
         ext_type = Path(i_path).suffix[1:].lower()
         # A raw disk image has no type of its own, only a conventional extension,
         # so the suffix taken literally ('img', 'bin') matches no branch in


### PR DESCRIPTION
Refuses to read one segment of a split raw image, and says when an image is shorter than the volumes it describes.

- A numbered suffix (.001) with its successor beside it is a split set. The raw seeker and the GUI stop before anything is staged and say to join the segments.
- qnxprobe re-vendored at 1.12: it reports IMAGE IS SHORTER THAN ITS PARTITION TABLE, marks each affected volume INCOMPLETE in volumes.json, and stores a file cut by the end of the image under a name that says how much of it is there.
- The seeker repeats the reader's finding in the run log as a WARNING naming each incomplete volume.
- 12 tests.

Measured on a Ford Sync G4 image cut at 1,500 MB: the storage volume, previously 0 files with no message, is reported as reaching 27.7 GiB past the end of the file, and the same file beside a .002 is refused. The full image draws no warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
