### PR TITLE
Re-vendor qnxprobe at 1.14 and vendor ewfprobe beside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ https://twitter.com/TroySchnack/status/1266085323651444736?s=19
 ### CLI
 
 ```
-$ python vleapp.py -t <zip | tar | fs | gz> -i <path_to_extraction> -o <path_for_report_output>
+$ python vleapp.py -t <fs | zip | tar | gz | file | raw | iva> -i <path_to_extraction> -o <path_for_report_output>
 ```
+
+`raw` reads a disk image, or an EnCase/EWF `.E01` acquisition and the segments beside
+it, without mounting and without administrator rights: its QNX6, QNX4, ext2/3/4, FAT32,
+exFAT or NTFS volumes and QNX IFS boot images are read directly. `iva` reads a Berla iVe
+export as it stands.
 
 ### GUI
 

--- a/scripts/search_files.py
+++ b/scripts/search_files.py
@@ -694,7 +694,9 @@ class FileSeekerRaw(FileSeekerZip):
     A split raw image (.001, .002, ...) is handed to the reader as it is: since
     qnxprobe 1.13 it joins every segment beside the one named, in order, and
     records the set in volumes.json, which _warn_incomplete_volumes() repeats
-    in the run log.
+    in the run log. An EnCase/EWF acquisition (.E01 and its numbered segments)
+    is handed over the same way and joined the same way, through the ewfprobe
+    vendored beside the reader.
 
     The zip is written to a temporary directory and removed by cleanup(). An
     examiner who wants to keep it, which is worth doing for a large image because

--- a/scripts/vendor/LICENSE-ewfprobe
+++ b/scripts/vendor/LICENSE-ewfprobe
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alexis Brignoni
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/vendor/README.md
+++ b/scripts/vendor/README.md
@@ -17,9 +17,24 @@ once and went stale on the first re-vendor, because prose is checked by nobody
 and the manifest is checked on every push.
 
 
-Reads QNX6 and ext2/3/4 volumes out of a raw image without mounting and with no
+Reads QNX6, QNX4, ext2/3/4, FAT32, exFAT, NTFS, the QNX flash filesystems ETFS
+and EFS, and QNX IFS boot images out of a raw image, without mounting and with no
 administrator rights. Python 3 standard library only, so vendoring it adds no
 dependency to requirements.txt.
+
+## ewfprobe.py
+
+| | |
+| --- | --- |
+| upstream | https://github.com/abrignoni/ewfprobe |
+| licence | MIT, kept beside it as LICENSE-ewfprobe |
+
+Reads an EnCase/EWF acquisition (`.E01` and its numbered segments) as an ordinary
+seekable image. qnxprobe imports it from this directory and, with it here, an
+`.E01` is a raw image input like any other; without it qnxprobe refuses an `.E01`
+with a message saying what is missing rather than reading it as raw bytes, which
+would find no filesystem and look like an empty image. Standard library only, so
+this adds no dependency either.
 
 **It is copied verbatim. Do not edit it here.** Fix upstream, then re-vendor, or
 the next sync silently reverts the change.
@@ -27,7 +42,12 @@ the next sync silently reverts the change.
 ### Re-vendoring
 
     cp ../qnxprobe/qnxprobe.py scripts/vendor/qnxprobe.py
+    cp ../ewfprobe/ewfprobe.py scripts/vendor/ewfprobe.py
     python3 admin/scripts/check_vendored.py --update
+
+`--update` rewrites the hashes only. The upstream commit and date in
+`vendored.json` are what say which version this is, so set those by hand from
+`git -C ../qnxprobe log -1 --format='%H %cI' main`.
 
 ### Checking for drift
 

--- a/scripts/vendor/ewfprobe.py
+++ b/scripts/vendor/ewfprobe.py
@@ -1,0 +1,740 @@
+"""ewfprobe: a read-only reader for EnCase/EWF (.E01) forensic images.
+
+One file, pure Python, standard library only. No compiler, no network, and
+nothing to install. It opens an EWF-E01 acquisition, joins its segments, and
+presents the original disk as an ordinary seekable file object, so anything
+that can read a raw image can read an E01 without changing how it reads.
+
+    with ewfprobe.open_ewf("evidence.E01") as img:
+        img.seek(0)
+        boot = img.read(512)
+
+The object answers ``seek``, ``tell``, ``read`` and ``close`` and works as a
+context manager, which is the whole interface a volume or filesystem parser
+needs.
+
+Written from the public format documentation: Joachim Metz, "Expert Witness
+Compression Format (EWF)", in the libyal/libewf repository under
+``documentation/``. No code is taken from libewf, which is LGPL, or from any
+other EWF implementation. This file is MIT, and reimplementing a documented
+format is what keeps it that way.
+
+Scope. This reads EWF-E01, the format EnCase 6 and 7 and FTK Imager write and
+by far the most common one in the field. It does not read the newer Ex01
+(EWF2), the SMART .s01 variant, or logical .L01 evidence, and it never writes.
+An image whose content is encrypted at rest, by BitLocker or FileVault or an
+encrypted APFS volume, reads back as the ciphertext that was acquired: the
+reader is working, there is simply nothing plain in there to find.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import hashlib
+import os
+import struct
+import sys
+import zlib
+from collections import OrderedDict
+
+__version__ = "0.1.0"
+
+# ---------------------------------------------------------------- constants
+
+SIGNATURE = b"EVF\x09\x0d\x0a\xff\x00"
+
+FILE_HEADER_SIZE = 13
+_FILE_HEADER = struct.Struct("<8sBHH")          # signature, 0x01, segment number, 0x0000
+
+SECTION_SIZE = 76
+_SECTION = struct.Struct("<16sQQ40sI")          # type, next offset, size, padding, checksum
+
+_TABLE_HEADER = struct.Struct("<IIQII")         # count, pad, base offset, pad, checksum
+TABLE_HEADER_SIZE = 24
+
+_COMPRESSED_BIT = 0x80000000
+_OFFSET_MASK = 0x7FFFFFFF
+
+MEDIA_TYPES = {0x00: "removable", 0x01: "fixed", 0x03: "optical", 0x0E: "logical"}
+COMPRESSION_LEVELS = {0x00: "none", 0x01: "good", 0x02: "best"}
+
+# How many decompressed chunks and open segment handles to keep. A chunk is
+# normally 32 KiB, so the cache is a couple of megabytes at the default.
+CHUNK_CACHE = 64
+MAX_OPEN = 8
+
+# The header sections name their fields with one or two letter identifiers.
+_HEADER_FIELDS = {
+    "c": "case_number",
+    "n": "evidence_number",
+    "a": "description",
+    "e": "examiner",
+    "t": "notes",
+    "av": "acquiry_software_version",
+    "ov": "operating_system",
+    "m": "acquisition_date",
+    "u": "system_date",
+    "p": "password_hash",
+    "pid": "process_identifier",
+    "dc": "unknown_dc",
+    "ext": "extents",
+    "r": "compression_level",
+}
+
+
+class EwfError(Exception):
+    """Base for everything this module raises."""
+
+
+class EwfFormatError(EwfError):
+    """The bytes are not a valid EWF-E01 image, or carry something unsupported."""
+
+
+class EwfIncompleteSetError(EwfError):
+    """A segment of a multi-segment acquisition is missing.
+
+    Raised rather than reading the segments that are present, because a partial
+    set reads as a small clean image and reports its missing data as empty.
+    """
+
+
+# ------------------------------------------------------------- segment names
+
+def _extension_sequence():
+    """The EWF segment extensions in order: E01 to E99, then EAA to ZZZ."""
+    for i in range(1, 100):
+        yield f"E{i:02d}"
+    for first in range(ord("E"), ord("Z") + 1):
+        for second in range(ord("A"), ord("Z") + 1):
+            for third in range(ord("A"), ord("Z") + 1):
+                yield chr(first) + chr(second) + chr(third)
+
+
+def is_ewf(path) -> bool:
+    """True when the file begins with the EWF signature."""
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(8) == SIGNATURE
+    except OSError:
+        return False
+
+
+def _stem_and_dir(path):
+    folder, name = os.path.split(os.path.abspath(path))
+    stem, dot, ext = name.rpartition(".")
+    if not dot:
+        raise EwfFormatError(f"{name} has no EWF extension")
+    return folder, stem, ext
+
+
+def ewf_segments(path) -> list[str]:
+    """Every segment file of the acquisition ``path`` belongs to, in order.
+
+    The set is built from the first segment onward, following the documented
+    extension sequence, and stops at the first extension that is not on disk.
+    Matching ignores case, because a set written on Windows and copied to a
+    case-sensitive volume can arrive as .e01. The returned paths are the names
+    as they actually sit on disk.
+    """
+    folder, stem, _ext = _stem_and_dir(path)
+    try:
+        present = {e.lower(): e for e in os.listdir(folder)}
+    except OSError as exc:
+        raise EwfFormatError(f"cannot list the folder holding the image: {exc}") from exc
+
+    segments = []
+    for ext in _extension_sequence():
+        want = f"{stem}.{ext}".lower()
+        actual = present.get(want)
+        if actual is None:
+            break
+        segments.append(os.path.join(folder, actual))
+    if not segments:
+        raise EwfFormatError(
+            f"{os.path.basename(path)} is not the first segment of an EWF set; "
+            f"the set is opened from its .E01")
+    return segments
+
+
+# ------------------------------------------------------------------ sections
+
+def _read_exactly(fh, n):
+    data = fh.read(n)
+    if len(data) != n:
+        raise EwfFormatError(f"short read: wanted {n} bytes, got {len(data)}")
+    return data
+
+
+def _sections(fh, segment_path):
+    """Yield (type, data_offset, data_size, next_offset) for one segment file."""
+    fh.seek(0)
+    head = _read_exactly(fh, FILE_HEADER_SIZE)
+    signature, one, segment_number, zero = _FILE_HEADER.unpack(head)
+    if signature != SIGNATURE:
+        raise EwfFormatError(f"{os.path.basename(segment_path)} is not an EWF file")
+    if one != 1 or zero != 0:
+        raise EwfFormatError(
+            f"{os.path.basename(segment_path)} has an unexpected file header")
+
+    offset = FILE_HEADER_SIZE
+    seen = set()
+    while True:
+        if offset in seen:                       # a self-referencing chain
+            raise EwfFormatError(
+                f"{os.path.basename(segment_path)} has a section loop at {offset}")
+        seen.add(offset)
+        fh.seek(offset)
+        raw = _read_exactly(fh, SECTION_SIZE)
+        stype, next_offset, size, _pad, _checksum = _SECTION.unpack(raw)
+        name = stype.split(b"\x00", 1)[0].decode("ascii", "replace")
+        data_offset = offset + SECTION_SIZE
+        if offset < next_offset:
+            # The next section's offset bounds this one exactly, which is not
+            # sensitive to whether the size field counts the descriptor.
+            data_size = max(0, next_offset - data_offset)
+        else:
+            data_size = max(0, size - SECTION_SIZE)
+        yield segment_number, name, data_offset, data_size, next_offset
+        # "next" and "done" both point at themselves and end the segment.
+        if name in ("next", "done") or next_offset == offset or next_offset == 0:
+            return
+        offset = next_offset
+
+
+def _compressed_bound(size):
+    """The most bytes a zlib stream of ``size`` bytes can occupy.
+
+    Deflate falls back to stored blocks when nothing compresses, which costs five
+    bytes per 65,535-byte block, on top of the zlib header and the Adler-32. The
+    margin is deliberately generous: a few bytes short would truncate a chunk, and a
+    few kilobytes long costs one short read.
+    """
+    return size + 5 * (size // 65535 + 1) + 1024
+
+
+def _inflate(data):
+    """Inflate a zlib stream, tolerating trailing bytes after its end."""
+    obj = zlib.decompressobj()
+    try:
+        out = obj.decompress(data)
+    except zlib.error as exc:
+        raise EwfFormatError(f"cannot inflate section data: {exc}") from exc
+    return out
+
+
+def _parse_header_text(text):
+    """The tab-delimited header section into a dict of friendly names."""
+    lines = [ln for ln in text.replace("\r\n", "\n").split("\n")]
+    fields = None
+    for i, line in enumerate(lines):
+        parts = line.split("\t")
+        if len(parts) > 2 and all(p.strip() in _HEADER_FIELDS for p in parts if p.strip()):
+            fields = [p.strip() for p in parts]
+            values = lines[i + 1].split("\t") if i + 1 < len(lines) else []
+            break
+    if not fields:
+        return {}
+    out = {}
+    for key, value in zip(fields, values):
+        value = value.strip()
+        if not value:
+            continue
+        out[_HEADER_FIELDS.get(key, key)] = value
+    return out
+
+
+# ---------------------------------------------------------------- the reader
+
+class _Table:
+    """One table section: a run of chunk offsets sharing a base offset.
+
+    ``entries`` stays as the raw little-endian bytes the file holds and each
+    offset is unpacked on demand. Reading them through ``array("I")`` instead
+    would take the item size from the host's C unsigned int and need a byteswap
+    on a big-endian host, so it would depend on the machine rather than on the
+    format, and a wrong item size would misparse the table silently.
+    """
+
+    __slots__ = ("segment", "base", "entries", "first_chunk", "limit")
+
+    def __init__(self, segment, base, entries, first_chunk, limit):
+        self.segment = segment
+        self.base = base
+        self.entries = entries
+        self.first_chunk = first_chunk
+        self.limit = limit
+
+
+class EwfImage:
+    """An EWF-E01 acquisition, read as one seekable stream of the acquired disk.
+
+    ``media_size`` is the size of the disk that was acquired, which is what
+    ``seek`` and ``read`` address. The segment files themselves are an
+    implementation detail and their sizes are not it.
+    """
+
+    def __init__(self, path, segments=None):
+        self.paths = list(segments) if segments else ewf_segments(path)
+        self._handles: OrderedDict[int, object] = OrderedDict()
+        self._cache: OrderedDict[int, bytes] = OrderedDict()
+        self._pos = 0
+        self._closed = False
+
+        self.sector_size = 0
+        self.sectors_per_chunk = 0
+        self.sector_count = 0
+        self.chunk_count = 0
+        self.media_type = None
+        self.compression_level = None
+        self.metadata: dict[str, str] = {}
+        self.stored_hashes: dict[str, str] = {}
+        self.checksum_errors: list[int] = []
+
+        self._tables: list[_Table] = []
+        self._table_starts: list[int] = []
+        self._index()
+
+    # -- construction ------------------------------------------------------
+
+    def _handle(self, i):
+        fh = self._handles.get(i)
+        if fh is None:
+            if len(self._handles) >= MAX_OPEN:
+                _old, stale = self._handles.popitem(last=False)
+                stale.close()
+            fh = open(self.paths[i], "rb")
+            self._handles[i] = fh
+        else:
+            self._handles.move_to_end(i)
+        return fh
+
+    def _index(self):
+        """Walk every segment once and build the chunk offset index."""
+        chunks = 0
+        volume_seen = False
+        last_name = None
+        for i, path in enumerate(self.paths):
+            fh = self._handle(i)
+            size_on_disk = os.path.getsize(path)
+            expect_segment = i + 1
+            for segno, name, offset, size, _next in _sections(fh, path):
+                if segno != expect_segment:
+                    raise EwfFormatError(
+                        f"{os.path.basename(path)} says it is segment {segno}, "
+                        f"but it sits at position {expect_segment} of the set")
+                last_name = name
+                if name in ("header", "header2") and not self.metadata:
+                    fh.seek(offset)
+                    raw = _inflate(_read_exactly(fh, size))
+                    if name == "header2":
+                        text = raw.decode("utf-16-le", "replace")
+                    else:
+                        text = raw.decode("latin-1", "replace")
+                    self.metadata = _parse_header_text(text)
+                elif name in ("volume", "disk") and not volume_seen:
+                    fh.seek(offset)
+                    self._parse_volume(_read_exactly(fh, min(size, 1052)))
+                    volume_seen = True
+                elif name == "table":
+                    chunks += self._parse_table(fh, i, offset, size, chunks, size_on_disk)
+                elif name in ("hash", "digest"):
+                    fh.seek(offset)
+                    self._parse_hashes(name, _read_exactly(fh, size))
+
+            if last_name == "next" and i == len(self.paths) - 1:
+                raise EwfIncompleteSetError(
+                    f"{os.path.basename(path)} ends with a 'next' section, so the "
+                    f"acquisition continues in a further segment that is not beside "
+                    f"it. Put every segment of the set in one folder before opening "
+                    f"it; reading only the segments present would report the missing "
+                    f"data as empty.")
+
+        if not volume_seen:
+            raise EwfFormatError("the image carries no volume section")
+        if not self._tables:
+            raise EwfFormatError("the image carries no chunk table")
+
+        self.chunk_size = self.sectors_per_chunk * self.sector_size
+        self.media_size = self.sector_count * self.sector_size
+        # ``size`` is the byte length of the acquired disk, which is what seek
+        # and read address. A consumer that already handles a joined set of raw
+        # segments asks an image object for exactly this, so answering it here
+        # lets such a consumer take an E01 without a special case.
+        self.size = self.media_size
+        # The size each segment FILE occupies on disk. These sum to the size of
+        # the acquisition on disk, not to media_size, because the chunks in them
+        # are usually compressed.
+        self.sizes = [os.path.getsize(p) for p in self.paths]
+        self._indexed_chunks = chunks
+        if chunks < self._needed_chunks():
+            raise EwfIncompleteSetError(
+                f"the chunk tables cover {chunks} chunks but the volume section "
+                f"describes {self._needed_chunks()}; the segment set is incomplete")
+
+    def _needed_chunks(self):
+        if not self.chunk_size:
+            return 0
+        return (self.media_size + self.chunk_size - 1) // self.chunk_size
+
+    def _parse_volume(self, data):
+        if len(data) < 24:
+            raise EwfFormatError("the volume section is too short")
+        self.media_type = MEDIA_TYPES.get(data[0], f"unknown ({data[0]:#04x})")
+        (chunk_count, sectors_per_chunk, bytes_per_sector) = struct.unpack_from("<III", data, 4)
+        sector_count = struct.unpack_from("<Q", data, 16)[0]
+        if len(data) >= 56:
+            level = data[52]
+            self.compression_level = COMPRESSION_LEVELS.get(level, f"unknown ({level:#04x})")
+        if not bytes_per_sector or not sectors_per_chunk or not sector_count:
+            raise EwfFormatError(
+                "the volume section gives a zero sector size, chunk size or sector count")
+        self.chunk_count = chunk_count
+        self.sectors_per_chunk = sectors_per_chunk
+        self.sector_size = bytes_per_sector
+        self.sector_count = sector_count
+
+    def _parse_table(self, fh, segment_index, offset, size, first_chunk, size_on_disk):
+        fh.seek(offset)
+        header = _read_exactly(fh, TABLE_HEADER_SIZE)
+        count, _pad1, base, _pad2, _checksum = _TABLE_HEADER.unpack(header)
+        if count == 0:
+            return 0
+        raw = _read_exactly(fh, count * 4)
+        table = _Table(segment_index, base, raw, first_chunk, size_on_disk)
+        self._table_starts.append(first_chunk)
+        self._tables.append(table)
+        return count
+
+    def _parse_hashes(self, name, data):
+        if name == "hash" and len(data) >= 16:
+            self.stored_hashes["MD5"] = data[:16].hex()
+        elif name == "digest" and len(data) >= 36:
+            md5, sha1 = data[:16], data[16:36]
+            if any(md5):
+                self.stored_hashes["MD5"] = md5.hex()
+            if any(sha1):
+                self.stored_hashes["SHA1"] = sha1.hex()
+
+    # -- chunk access ------------------------------------------------------
+
+    def _chunk_location(self, n):
+        i = bisect.bisect_right(self._table_starts, n) - 1
+        if i < 0:
+            raise EwfFormatError(f"chunk {n} is before the first table")
+        table = self._tables[i]
+        k = n - table.first_chunk
+        if (k + 1) * 4 > len(table.entries):
+            raise EwfFormatError(f"chunk {n} is past the end of the chunk tables")
+        entry = struct.unpack_from("<I", table.entries, k * 4)[0]
+        start = table.base + (entry & _OFFSET_MASK)
+        compressed = bool(entry & _COMPRESSED_BIT)
+        if (k + 2) * 4 <= len(table.entries):
+            nxt = struct.unpack_from("<I", table.entries, (k + 1) * 4)[0]
+            end = table.base + (nxt & _OFFSET_MASK)
+        else:
+            end = table.limit
+        if end <= start:
+            end = table.limit
+        # The last entry of a table has no next entry to bound it, so the fallback is
+        # the end of the segment file. On a real acquisition that is most of a gigabyte
+        # read and allocated to produce one 32 KiB chunk: measured on a 232.9 GiB FTK
+        # Imager set of 15 segments, 471 tables whose last-chunk spans summed to 364 GB,
+        # the worst single one 1.47 GB. A chunk holds chunk_size bytes, so its stored
+        # form cannot be longer than deflate can make of that, whatever the section
+        # boundary says.
+        end = min(end, start + _compressed_bound(self.chunk_size))
+        return table.segment, start, end, compressed
+
+    def _chunk(self, n):
+        cached = self._cache.get(n)
+        if cached is not None:
+            self._cache.move_to_end(n)
+            return cached
+
+        segment, start, end, compressed = self._chunk_location(n)
+        want = self.chunk_size
+        if n == self._needed_chunks() - 1:
+            tail = self.media_size % self.chunk_size
+            if tail:
+                want = tail
+
+        fh = self._handle(segment)
+        fh.seek(start)
+        if compressed:
+            # zlib stops at the end of its own stream, so the slice only has to
+            # be long enough, which sidesteps the format not recording sizes.
+            raw = fh.read(max(0, end - start))
+            data = _inflate(raw)
+        else:
+            data = fh.read(want)
+            stored = fh.read(4)
+            if len(stored) == 4:
+                if zlib.adler32(data) & 0xFFFFFFFF != struct.unpack("<I", stored)[0]:
+                    if n not in self.checksum_errors:
+                        self.checksum_errors.append(n)
+        if len(data) < want:
+            data = data + b"\x00" * (want - len(data))
+        elif len(data) > want:
+            data = data[:want]
+
+        if len(self._cache) >= CHUNK_CACHE:
+            self._cache.popitem(last=False)
+        self._cache[n] = data
+        return data
+
+    # -- the file-like surface --------------------------------------------
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        if self._closed:
+            raise ValueError("seek on a closed image")
+        if whence == os.SEEK_SET:
+            pos = offset
+        elif whence == os.SEEK_CUR:
+            pos = self._pos + offset
+        elif whence == os.SEEK_END:
+            pos = self.media_size + offset
+        else:
+            raise ValueError(f"invalid whence: {whence}")
+        if pos < 0:
+            raise ValueError("negative seek position")
+        self._pos = pos
+        return self._pos
+
+    def tell(self):
+        return self._pos
+
+    def read(self, n=-1):
+        if self._closed:
+            raise ValueError("read on a closed image")
+        if self._pos >= self.media_size:
+            return b""
+        remaining = self.media_size - self._pos
+        if n is None or n < 0 or n > remaining:
+            n = remaining
+        out = bytearray()
+        pos = self._pos
+        while n > 0:
+            index = pos // self.chunk_size
+            within = pos % self.chunk_size
+            chunk = self._chunk(index)
+            take = min(n, len(chunk) - within)
+            if take <= 0:
+                break
+            out += chunk[within:within + take]
+            pos += take
+            n -= take
+        self._pos = pos
+        return bytes(out)
+
+    def readable(self):
+        return True
+
+    def seekable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def close(self):
+        if self._closed:
+            return
+        for fh in self._handles.values():
+            try:
+                fh.close()
+            except OSError:
+                pass
+        self._handles.clear()
+        self._cache.clear()
+        self._closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+    # -- verification ------------------------------------------------------
+
+    def verify(self, progress=None, block=1 << 22):
+        """Recompute the media hashes and compare them with the stored ones.
+
+        Returns a dict with the computed digests, the stored digests, and a
+        ``match`` value that is True, False, or None when the acquisition
+        recorded no hash to compare against.
+        """
+        md5 = hashlib.md5()
+        sha1 = hashlib.sha1()
+        self.seek(0)
+        done = 0
+        while True:
+            data = self.read(block)
+            if not data:
+                break
+            md5.update(data)
+            sha1.update(data)
+            done += len(data)
+            if progress:
+                progress(done, self.media_size)
+        computed = {"MD5": md5.hexdigest(), "SHA1": sha1.hexdigest()}
+        match = None
+        for name, value in self.stored_hashes.items():
+            if name in computed:
+                match = (computed[name] == value) if match in (None, True) else False
+        return {
+            "computed": computed,
+            "stored": dict(self.stored_hashes),
+            "match": match,
+            "bytes": done,
+            "checksum_errors": list(self.checksum_errors),
+        }
+
+    def info(self):
+        """Everything worth printing about the acquisition, as a dict."""
+        return {
+            "segments": [os.path.basename(p) for p in self.paths],
+            "segment_count": len(self.paths),
+            "media_type": self.media_type,
+            "media_size": self.media_size,
+            "sector_size": self.sector_size,
+            "sector_count": self.sector_count,
+            "sectors_per_chunk": self.sectors_per_chunk,
+            "chunk_size": self.chunk_size,
+            "chunk_count": self.chunk_count,
+            "indexed_chunks": self._indexed_chunks,
+            "compression_level": self.compression_level,
+            "stored_hashes": dict(self.stored_hashes),
+            "metadata": dict(self.metadata),
+        }
+
+
+def open_ewf(path, segments=None) -> EwfImage:
+    """Open an EWF acquisition from any path in its segment set."""
+    return EwfImage(path, segments=segments)
+
+
+# --------------------------------------------------------------------- CLI
+
+def _size(n):
+    v = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if v < 1024 or unit == "TiB":
+            return f"{v:,.1f} {unit}" if unit != "B" else f"{int(v)} B"
+        v /= 1024
+    return f"{v} B"
+
+
+def _cmd_info(args):
+    with open_ewf(args.image) as img:
+        d = img.info()
+        print(f"image           {os.path.basename(args.image)}")
+        print(f"segments        {d['segment_count']} ({d['segments'][0]}"
+              f"{' .. ' + d['segments'][-1] if d['segment_count'] > 1 else ''})")
+        print(f"media type      {d['media_type']}")
+        print(f"media size      {d['media_size']:,} bytes ({_size(d['media_size'])})")
+        print(f"sector size     {d['sector_size']:,} bytes")
+        print(f"sectors         {d['sector_count']:,}")
+        print(f"chunk size      {d['chunk_size']:,} bytes "
+              f"({d['sectors_per_chunk']} sectors)")
+        print(f"chunks          {d['indexed_chunks']:,} indexed, "
+              f"{d['chunk_count']:,} declared")
+        print(f"compression     {d['compression_level']}")
+        for name, value in d["stored_hashes"].items():
+            print(f"stored {name:<9}{value}")
+        if d["metadata"]:
+            print("metadata")
+            for key, value in d["metadata"].items():
+                print(f"  {key:<26}{value}")
+    return 0
+
+
+def _progress(done, total):
+    if not total:
+        return
+    pct = 100.0 * done / total
+    sys.stderr.write(f"\r  {pct:5.1f}%  {_size(done)} of {_size(total)}")
+    sys.stderr.flush()
+
+
+def _cmd_verify(args):
+    with open_ewf(args.image) as img:
+        result = img.verify(progress=None if args.quiet else _progress)
+        if not args.quiet:
+            sys.stderr.write("\r" + " " * 48 + "\r")
+        for name, value in result["computed"].items():
+            stored = result["stored"].get(name)
+            if stored is None:
+                print(f"{name:<6}{value}   (none stored)")
+            elif stored == value:
+                print(f"{name:<6}{value}   matches the stored hash")
+            else:
+                print(f"{name:<6}{value}   DOES NOT MATCH stored {stored}")
+        if result["checksum_errors"]:
+            print(f"chunk checksum mismatches: {len(result['checksum_errors'])}")
+        if result["match"] is None:
+            print("the acquisition recorded no hash, so nothing could be compared")
+            return 0
+        return 0 if result["match"] else 1
+
+
+def _cmd_export(args):
+    with open_ewf(args.image) as img:
+        total = img.media_size
+        img.seek(args.offset)
+        remaining = total - args.offset if args.length is None else args.length
+        out = sys.stdout.buffer if args.output == "-" else open(args.output, "wb")
+        try:
+            done = 0
+            while remaining > 0:
+                data = img.read(min(1 << 22, remaining))
+                if not data:
+                    break
+                out.write(data)
+                done += len(data)
+                remaining -= len(data)
+                if not args.quiet and args.output != "-":
+                    _progress(done, total - args.offset)
+        finally:
+            if out is not sys.stdout.buffer:
+                out.close()
+        if not args.quiet and args.output != "-":
+            sys.stderr.write("\r" + " " * 48 + "\r")
+    return 0
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="ewfprobe",
+        description="Read an EnCase/EWF (.E01) forensic image. Read only.")
+    ap.add_argument("--version", action="version", version=f"ewfprobe {__version__}")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("info", help="print the acquisition's geometry and metadata")
+    s.add_argument("image")
+    s.set_defaults(func=_cmd_info)
+
+    s = sub.add_parser("verify", help="recompute the media hash and compare it "
+                                      "with the one the acquisition stored")
+    s.add_argument("image")
+    s.add_argument("-q", "--quiet", action="store_true", help="no progress output")
+    s.set_defaults(func=_cmd_verify)
+
+    s = sub.add_parser("export", help="write the acquired disk out as a raw image")
+    s.add_argument("image")
+    s.add_argument("-o", "--output", default="-", help="output file, or - for stdout")
+    s.add_argument("--offset", type=int, default=0, help="start at this byte offset")
+    s.add_argument("--length", type=int, default=None, help="write this many bytes")
+    s.add_argument("-q", "--quiet", action="store_true", help="no progress output")
+    s.set_defaults(func=_cmd_export)
+
+    args = ap.parse_args(argv)
+    try:
+        return args.func(args)
+    except EwfError as exc:
+        print(f"ewfprobe: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vendor/qnxprobe.py
+++ b/scripts/vendor/qnxprobe.py
@@ -27,7 +27,21 @@ Read-only throughout. Never writes to the image.
 """
 import os, re, struct, sys, datetime, json, time, uuid, zipfile, bisect, collections
 
-QNXPROBE_VERSION = "1.13"
+# ewfprobe is vendored beside this file (see vendored.json) so an EnCase/EWF
+# .E01 acquisition can be read as an ordinary image. It is optional: without it
+# everything else works exactly as before, and an .E01 is refused with a message
+# saying what is missing rather than being read as raw bytes, which would find
+# no filesystem and look like an empty image.
+try:
+    import ewfprobe
+except ImportError:                  # not on sys.path when imported as a module
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    try:
+        import ewfprobe
+    except ImportError:
+        ewfprobe = None
+
+QNXPROBE_VERSION = "1.14"
 
 QNX6_MAGIC     = 0x68191122
 BOOTBLOCK_SIZE = 0x2000
@@ -119,6 +133,40 @@ def read_at(fh, off, n):
     if len(data) < n:
         EOF_SHORTFALL["bytes"] += n - len(data)
     return data
+
+
+class ImageUnreadable(Exception):
+    """This tool cannot open the image, and the message says why."""
+
+
+EWF_SIGNATURE = b"EVF\x09\x0d\x0a\xff\x00"
+
+
+def _ewf_refused_by_reader(path):
+    """True when the vendored reader rejects a damaged acquisition rather than
+    returning something that would be walked as though it were an image."""
+    if ewfprobe is None:
+        return True
+    try:
+        ewfprobe.open_ewf(path)
+    except ewfprobe.EwfError:
+        return True
+    except Exception:
+        return False
+    return False
+
+
+def looks_like_ewf(path):
+    """True when the file begins with the EWF signature.
+
+    Checked here rather than in ewfprobe so an .E01 is still recognised, and
+    refused with a useful message, when the vendored reader is absent.
+    """
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(8) == EWF_SIGNATURE
+    except OSError:
+        return False
 
 
 class SplitImageError(Exception):
@@ -282,13 +330,33 @@ def image_size(fh):
     size = getattr(fh, "size", None)
     if size is not None:
         return size
-    return os.fstat(fh.fileno()).st_size
+    try:
+        return os.fstat(fh.fileno()).st_size
+    except (AttributeError, OSError, ValueError):
+        # No file descriptor behind it. Anything seekable can still say where
+        # its end is, which is what a reader over a container answers to.
+        here = fh.tell()
+        try:
+            fh.seek(0, os.SEEK_END)
+            return fh.tell()
+        finally:
+            fh.seek(here)
 
 
 def open_image(path, segments=None):
     """Open an image read-only: the one file, or every segment of the split
     image it belongs to, joined. segments is split_segments(path) when the
     caller already has it."""
+    if looks_like_ewf(path):
+        if ewfprobe is None:
+            raise ImageUnreadable(
+                f"{os.path.basename(path)} is an EnCase/EWF (.E01) acquisition. "
+                f"Reading one needs ewfprobe.py beside this script; it is "
+                f"normally vendored here (see vendored.json) and is missing. "
+                f"Export the image to raw, or put ewfprobe.py back.")
+        # ewfprobe joins the segments of the set itself, from the format's own
+        # records rather than from the file names, and refuses an incomplete set.
+        return ewfprobe.open_ewf(path)
     if segments is None:
         segments = split_segments(path)
     if segments:
@@ -430,11 +498,12 @@ def parse_mbr(fh):
     mbr = read_at(fh, 0, 512)
     if len(mbr) < 512 or mbr[510:512] != b"\x55\xaa":
         return None
-    # A FAT or exFAT boot sector also ends in 0x55AA, and its boot code sits
-    # where MBR partition entries would be, so it parses as four nonsense
-    # partitions. Its own type string at bytes 3..11 (exFAT) or 82..90 (FAT32)
-    # says it is a filesystem, not a partition table.
-    if mbr[3:11] == b"EXFAT   " or mbr[82:90] == b"FAT32   " or mbr[54:62] == b"FAT16   ":
+    # A FAT, exFAT or NTFS boot sector also ends in 0x55AA, and its boot code
+    # sits where MBR partition entries would be, so it parses as four nonsense
+    # partitions. Its own type string at bytes 3..11 (exFAT, NTFS) or 82..90
+    # (FAT32) says it is a filesystem, not a partition table.
+    if (mbr[3:11] in (b"EXFAT   ", b"NTFS    ")
+            or mbr[82:90] == b"FAT32   " or mbr[54:62] == b"FAT16   "):
         return None
     # A QNX4 boot block can also end in 0x55AA (the dinit boot sector does).
     # The QNX4 superblock is the NEXT sector: its first entry is the root
@@ -1033,6 +1102,577 @@ QNX4_F_USED, QNX4_F_LINK = 0x01, 0x08
 QNX4_XBLK_SIG = b"IamXblk"    # fs/qnx4/inode.c:110 checks these 7 bytes
 
 
+# ---------------------------------------------------------------- NTFS
+# Field offsets and structure layouts below come from the Linux-NTFS project's
+# published NTFS documentation (Richard Russon and Yuval Fledel, "NTFS
+# Documentation", https://flatcap.github.io/linux-ntfs/ntfs/), which describes
+# the on-disk format independently of any implementation, and are confirmed
+# against a volume written by mkntfs. No NTFS implementation's source was read
+# for this: ntfs-3g and The Sleuth Kit are both under licences this file is not.
+
+NTFS_OEM = b"NTFS    "
+NTFS_ROOT = 5                       # the root directory is always MFT record 5
+NTFS_FILE = b"FILE"
+NTFS_INDX = b"INDX"
+
+# attribute types this walker reads
+NTFS_STANDARD_INFORMATION = 0x10
+NTFS_ATTRIBUTE_LIST       = 0x20
+NTFS_FILE_NAME            = 0x30
+NTFS_DATA                 = 0x80
+NTFS_INDEX_ROOT           = 0x90
+NTFS_INDEX_ALLOCATION     = 0xA0
+NTFS_END                  = 0xFFFFFFFF
+
+NTFS_ATTR_COMPRESSED = 0x0001
+NTFS_ATTR_ENCRYPTED  = 0x4000
+NTFS_ATTR_SPARSE     = 0x8000
+
+NTFS_MFT_IN_USE   = 0x0001
+NTFS_MFT_IS_DIR   = 0x0002
+
+# FILETIME counts 100 ns ticks from 1601-01-01 UTC; this is the gap to the Unix epoch.
+NTFS_EPOCH_DELTA = 11644473600
+
+
+class NtfsUnreadable(Exception):
+    """A file whose bytes this walker will not guess at (encrypted, or an
+    attribute shape it does not implement). Raised rather than returning short
+    data, because a short read here would be indistinguishable from a small file."""
+
+
+def ntfs_time(v):
+    """A FILETIME as Unix seconds, or 0 when it is unset or out of range."""
+    if not v:
+        return 0
+    sec = v / 10_000_000 - NTFS_EPOCH_DELTA
+    return sec if -12219292800 < sec < 253402300799 else 0
+
+
+def _ntfs_fixup(buf, per, name):
+    """Apply the update sequence array to a multi-sector record.
+
+    NTFS stamps the last two bytes of every sector of a record with one value
+    and keeps the real bytes in an array in the header, so a torn write is
+    detectable. The record cannot be parsed until they are put back.
+    """
+    if len(buf) < 8:
+        return None
+    if buf[0:4] != name:
+        return None
+    off, count = struct.unpack_from("<HH", buf, 4)
+    if count < 1 or off + count * 2 > len(buf):
+        return None
+    usn = buf[off:off + 2]
+    out = bytearray(buf)
+    for i in range(count - 1):
+        end = (i + 1) * per
+        if end > len(out):
+            break
+        if bytes(out[end - 2:end]) != usn:
+            return None                 # a sector that was not written with the rest
+        out[end - 2:end] = buf[off + 2 + i * 2: off + 4 + i * 2]
+    return bytes(out)
+
+
+def _ntfs_runs(data, offset, cluster_count):
+    """Decode a mapping-pair list into [(lcn or None, clusters)], in VCN order.
+
+    Each pair is a header byte giving the width of a length field and of an
+    offset field, then those two fields. The offset is signed and relative to
+    the previous run's start, and a zero-width offset means the run is sparse:
+    it occupies VCNs and no clusters, and reads as zeros.
+    """
+    runs, pos, lcn, seen = [], offset, 0, 0
+    while pos < len(data):
+        head = data[pos]
+        if head == 0:
+            break
+        len_size, off_size = head & 0x0F, head >> 4
+        pos += 1
+        if len_size == 0 or pos + len_size + off_size > len(data):
+            return None
+        length = int.from_bytes(data[pos:pos + len_size], "little", signed=False)
+        pos += len_size
+        if off_size:
+            delta = int.from_bytes(data[pos:pos + off_size], "little", signed=True)
+            pos += off_size
+            lcn += delta
+            runs.append((lcn, length))
+        else:
+            runs.append((None, length))     # sparse
+        seen += length
+        if cluster_count and seen > cluster_count + 1:
+            return None                      # the list describes more than the attribute holds
+    return runs
+
+
+class _NtfsAttr:
+    """One attribute of an MFT record, resident or not."""
+
+    __slots__ = ("type", "name", "flags", "resident", "value", "runs",
+                 "data_size", "alloc_size", "init_size", "comp_unit", "start_vcn")
+
+    def __init__(self, type_, name, flags, resident):
+        self.type, self.name, self.flags, self.resident = type_, name, flags, resident
+        self.value = b""
+        self.runs = []
+        self.data_size = self.alloc_size = self.init_size = 0
+        self.comp_unit = 0
+        self.start_vcn = 0
+
+    @property
+    def compressed(self):
+        return bool(self.flags & NTFS_ATTR_COMPRESSED) and self.comp_unit
+
+    @property
+    def encrypted(self):
+        return bool(self.flags & NTFS_ATTR_ENCRYPTED)
+
+
+class NtfsWalker:
+    """List and read files from an NTFS volume, same interface as the walkers
+    above. A node is the MFT record number, which is what a directory index
+    stores and what makes two names for one file resolve to one record.
+
+    What it reads: resident and non-resident $DATA, sparse runs, LZNT1
+    compressed data, attributes that overflow into other records through
+    $ATTRIBUTE_LIST, and directory indexes in both their resident ($INDEX_ROOT)
+    and allocated ($INDEX_ALLOCATION) forms, with the sector fixups applied.
+
+    What it does not read: an encrypted file's content, which needs a key the
+    volume does not hold. Those are listed with their recorded size and refuse
+    to be read rather than yielding the ciphertext as though it were the file.
+    Only the unnamed $DATA stream is the file's content; a named stream is
+    reported through named_streams() and never as a file of its own.
+    """
+
+    root = NTFS_ROOT
+
+    def __init__(self, fh, base):
+        self.fh, self.base = fh, base
+        boot = read_at(fh, base, 512)
+        if len(boot) < 512 or boot[3:11] != NTFS_OEM:
+            raise ValueError("not an NTFS boot sector")
+        self.bps = struct.unpack_from("<H", boot, 11)[0]
+        self.spc = boot[13]
+        if not self.bps or not self.spc:
+            raise ValueError("NTFS boot sector gives a zero sector or cluster size")
+        self.cluster = self.bps * self.spc
+        self.total_sectors = struct.unpack_from("<Q", boot, 40)[0]
+        self.mft_lcn = struct.unpack_from("<Q", boot, 48)[0]
+        self.mftmirr_lcn = struct.unpack_from("<Q", boot, 56)[0]
+        self.rec_size = self._sized(struct.unpack_from("<b", boot, 64)[0])
+        self.idx_size = self._sized(struct.unpack_from("<b", boot, 68)[0])
+        self.serial = struct.unpack_from("<Q", boot, 72)[0]
+        self.volume_size = self.total_sectors * self.bps
+        self._records = {}                       # record number -> attributes
+        self._mft_runs = None
+        self._mft_runs = self._read_mft_runs()
+
+    def _sized(self, raw):
+        """A size field that is a cluster count when positive and a power of two
+        byte count when negative, which is how a 1 KiB record fits a 4 KiB cluster."""
+        return raw * self.cluster if raw > 0 else 1 << (-raw)
+
+    # -- raw access --------------------------------------------------------
+    def _read_runs(self, runs, want, start=0):
+        """Bytes from a run list, sparse runs reading as the zeros they stand for."""
+        out = bytearray()
+        pos = 0
+        for lcn, count in runs:
+            span = count * self.cluster
+            if pos + span <= start:
+                pos += span
+                continue
+            skip = max(0, start - pos)
+            take = min(span - skip, want - len(out))
+            if lcn is None:
+                out += b"\x00" * take
+            else:
+                out += read_at(self.fh, self.base + lcn * self.cluster + skip, take)
+            pos += span
+            if len(out) >= want:
+                break
+        return bytes(out[:want])
+
+    def _read_mft_runs(self):
+        """The $MFT's own data runs, read from record 0, which sits at a cluster
+        the boot sector names. Every other record is then found through them."""
+        off = self.base + self.mft_lcn * self.cluster
+        raw = _ntfs_fixup(read_at(self.fh, off, self.rec_size), self.bps, NTFS_FILE)
+        if raw is None:
+            raise ValueError("the MFT's own record is unreadable")
+        attrs = self._parse_attrs(raw, follow_list=False)
+        for a in attrs:
+            if a.type == NTFS_DATA and not a.name and not a.resident:
+                return a.runs
+        raise ValueError("the MFT record carries no non-resident data attribute")
+
+    def _record(self, num):
+        """The attributes of one MFT record, cached."""
+        got = self._records.get(num)
+        if got is None:
+            off = num * self.rec_size
+            raw = self._read_runs(self._mft_runs, self.rec_size, off) if self._mft_runs \
+                else read_at(self.fh, self.base + self.mft_lcn * self.cluster + off,
+                             self.rec_size)
+            fixed = _ntfs_fixup(raw, self.bps, NTFS_FILE)
+            got = self._parse_attrs(fixed, self_ref=num) if fixed else []
+            self._records[num] = got
+        return got
+
+    def _parse_attrs(self, raw, follow_list=True, self_ref=None):
+        """Every attribute in one record, plus those its $ATTRIBUTE_LIST points at.
+
+        A record that runs out of room moves attributes into other records and
+        leaves a list saying where they went. Following it is what makes a very
+        fragmented file readable, since its run list is what overflowed.
+        """
+        if not raw or len(raw) < 0x30:
+            return []
+        first, flags = struct.unpack_from("<HH", raw, 0x14)
+        used = struct.unpack_from("<I", raw, 0x18)[0]
+        if not flags & NTFS_MFT_IN_USE:
+            return []
+        out, pos, limit = [], first, min(used or len(raw), len(raw))
+        while pos + 4 <= limit:
+            type_ = struct.unpack_from("<I", raw, pos)[0]
+            if type_ == NTFS_END:
+                break
+            if pos + 16 > limit:
+                break
+            length = struct.unpack_from("<I", raw, pos + 4)[0]
+            if length < 16 or pos + length > limit:
+                break
+            attr = self._parse_one(raw, pos, length)
+            if attr:
+                out.append(attr)
+            pos += length
+        out.append(_NtfsAttr(-1, "", flags, True))       # carries the record flags
+        if follow_list:
+            out.extend(self._follow_attribute_list(out, self_ref))
+        return out
+
+    def _parse_one(self, raw, pos, length):
+        type_ = struct.unpack_from("<I", raw, pos)[0]
+        nonres = raw[pos + 8]
+        name_len = raw[pos + 9]
+        name_off = struct.unpack_from("<H", raw, pos + 10)[0]
+        flags = struct.unpack_from("<H", raw, pos + 12)[0]
+        name = ""
+        if name_len:
+            end = pos + name_off + name_len * 2
+            if end <= pos + length:
+                name = raw[pos + name_off:end].decode("utf-16-le", "replace")
+        attr = _NtfsAttr(type_, name, flags, not nonres)
+        if not nonres:
+            vlen, voff = struct.unpack_from("<IH", raw, pos + 16)
+            if pos + voff + vlen > pos + length:
+                return None
+            attr.value = raw[pos + voff:pos + voff + vlen]
+            attr.data_size = vlen
+            return attr
+        start_vcn, last_vcn = struct.unpack_from("<QQ", raw, pos + 16)
+        run_off, comp = struct.unpack_from("<HH", raw, pos + 32)
+        alloc, real, init = struct.unpack_from("<QQQ", raw, pos + 40)
+        attr.start_vcn, attr.comp_unit = start_vcn, comp
+        attr.alloc_size, attr.data_size, attr.init_size = alloc, real, init
+        if run_off >= length:
+            return None
+        attr.runs = _ntfs_runs(raw[pos:pos + length], run_off,
+                               last_vcn - start_vcn + 1) or []
+        return attr
+
+    def _follow_attribute_list(self, attrs, self_ref=None):
+        """Attributes this record delegated to others, read from those records.
+
+        The list names every attribute of the file, including the ones that
+        stayed put, so it points back at this record too. Reading that one again
+        would count its attributes twice: measured on a 333-run file, the data
+        runs came out at 537 and the file read long and wrong.
+        """
+        extra, seen = [], set()
+        for a in attrs:
+            if a.type != NTFS_ATTRIBUTE_LIST:
+                continue
+            data = a.value if a.resident else self._read_runs(a.runs, a.data_size)
+            pos = 0
+            while pos + 26 <= len(data):
+                rec_len = struct.unpack_from("<H", data, pos + 4)[0]
+                if rec_len < 26 or pos + rec_len > len(data):
+                    break
+                ref = struct.unpack_from("<Q", data, pos + 16)[0] & 0xFFFFFFFFFFFF
+                if ref and ref != self_ref and ref not in seen:
+                    seen.add(ref)
+                pos += rec_len
+        for ref in seen:
+            off = ref * self.rec_size
+            raw = self._read_runs(self._mft_runs, self.rec_size, off)
+            fixed = _ntfs_fixup(raw, self.bps, NTFS_FILE)
+            if fixed:
+                extra.extend(a for a in self._parse_attrs(fixed, follow_list=False)
+                             if a.type not in (-1, NTFS_ATTRIBUTE_LIST))
+        return extra
+
+    # -- the walker surface ------------------------------------------------
+    def _data_attr(self, num, name=""):
+        """The named (or unnamed) $DATA attribute, with the runs of every piece
+        joined: a file whose run list overflowed carries one $DATA per VCN span."""
+        parts = [a for a in self._record(num)
+                 if a.type == NTFS_DATA and a.name == name]
+        if not parts:
+            return None
+        resident = [a for a in parts if a.resident]
+        if resident:
+            return resident[0]
+        parts.sort(key=lambda a: a.start_vcn)
+        head = parts[0]
+        joined = _NtfsAttr(NTFS_DATA, name, head.flags, False)
+        joined.comp_unit = head.comp_unit
+        joined.alloc_size = max(a.alloc_size for a in parts)
+        joined.data_size = max(a.data_size for a in parts)
+        joined.init_size = max(a.init_size for a in parts)
+        for a in parts:
+            joined.runs.extend(a.runs)
+        return joined
+
+    def volume_label(self):
+        """The volume label, from the $VOLUME_NAME attribute of record 3, or None
+        when the record cannot be read. An empty string means the volume has none."""
+        for a in self._record(3):
+            if a.type == 0x60 and a.resident:
+                return a.value.decode("utf-16-le", "replace")
+        return "" if self._record(3) else None
+
+    def _flags(self, num):
+        for a in self._record(num):
+            if a.type == -1:
+                return a.flags
+        return 0
+
+    def inode(self, num):
+        return num
+
+    def entry(self, num):
+        attrs = self._record(num)
+        if not attrs:
+            return None
+        is_dir = bool(self._flags(num) & NTFS_MFT_IS_DIR)
+        mtime = 0
+        for a in attrs:
+            if a.type == NTFS_STANDARD_INFORMATION and a.resident and len(a.value) >= 24:
+                mtime = ntfs_time(struct.unpack_from("<Q", a.value, 8)[0])
+                break
+        if is_dir:
+            return (S_IFDIR | 0o755, 0, mtime)
+        data = self._data_attr(num)
+        size = 0 if data is None else (len(data.value) if data.resident else data.data_size)
+        return (0o100644, size, mtime)
+
+    def named_streams(self, num):
+        """[(name, size)] for every alternate data stream on this record. A named
+        stream is content the file's own size does not account for, so it is worth
+        reporting; it is not listed as a file, because it has no name of its own."""
+        out = []
+        for a in self._record(num):
+            if a.type == NTFS_DATA and a.name:
+                out.append((a.name, len(a.value) if a.resident else a.data_size))
+        return out
+
+    def listdir(self, num):
+        """(name, record) for every entry of a directory index.
+
+        The index lives in $INDEX_ROOT while it is small and moves into
+        $INDEX_ALLOCATION blocks when it grows; both hold the same entry shape,
+        so both are walked with one reader.
+        """
+        out, seen = [], set()
+        root = alloc = None
+        for a in self._record(num):
+            if a.type == NTFS_INDEX_ROOT and a.name == "$I30":
+                root = a
+            elif a.type == NTFS_INDEX_ALLOCATION and a.name == "$I30":
+                alloc = a
+        if root is None:
+            return out
+        # $INDEX_ROOT: a small header, then the index header at 0x10
+        if len(root.value) >= 0x20:
+            self._index_entries(root.value, 0x10, out, seen)
+        if alloc is not None and alloc.runs:
+            total = alloc.data_size or alloc.alloc_size
+            step = self.idx_size
+            for off in range(0, total, step):
+                block = _ntfs_fixup(self._read_runs(alloc.runs, step, off),
+                                    self.bps, NTFS_INDX)
+                if block and len(block) >= 0x28:
+                    self._index_entries(block, 0x18, out, seen)
+        return out
+
+    def _index_entries(self, buf, header_off, out, seen):
+        """Append the entries of one index header. Entry offsets are relative to
+        the header, not to the record, which is why the caller passes its offset."""
+        if header_off + 16 > len(buf):
+            return
+        first, total = struct.unpack_from("<II", buf, header_off)
+        pos = header_off + first
+        end = min(header_off + total, len(buf))
+        while pos + 0x52 <= end:
+            ref, elen, klen, eflags = struct.unpack_from("<QHHH", buf, pos)
+            if elen < 0x10 or pos + elen > end:
+                break
+            if eflags & 0x02:                       # the last entry holds no name
+                break
+            rec = ref & 0xFFFFFFFFFFFF
+            if klen >= 0x42:
+                name_len = buf[pos + 0x50]
+                namespace = buf[pos + 0x51]
+                nstart = pos + 0x52
+                nend = nstart + name_len * 2
+                if nend <= pos + elen:
+                    name = buf[nstart:nend].decode("utf-16-le", "replace")
+                    # Namespace 2 is the 8.3 name of a file that also has a long
+                    # one, indexed beside it. Reporting both would list every such
+                    # file twice under two names. The root's index also carries an
+                    # entry for the root itself, which is a loop, not a child.
+                    if (namespace != 2 and name not in (".", "..")
+                            and (rec, name) not in seen):
+                        seen.add((rec, name))
+                        out.append((name, rec))
+            pos += elen
+
+    def read_file(self, num, size):
+        data = self._data_attr(num)
+        if data is None:
+            return
+        if data.resident:
+            yield data.value[:size] if size else data.value
+            return
+        if data.encrypted:
+            raise NtfsUnreadable("the file is encrypted and the volume holds no key")
+        want = size if size is not None else data.data_size
+        want = min(want, data.data_size) if data.data_size else want
+        if data.compressed:
+            yield from self._read_compressed(data, want)
+            return
+        # Everything past the initialized size reads as zero even though the
+        # clusters are allocated and still hold whatever was there before. A
+        # database that preallocates its file is the common case: two on this
+        # Windows volume differed from The Sleuth Kit's reading by exactly that
+        # tail until it was honoured. The stale bytes are slack, not content.
+        real = min(want, data.init_size) if data.init_size else 0
+        done = 0
+        while done < real:
+            chunk = self._read_runs(data.runs, min(1 << 20, real - done), done)
+            if not chunk:
+                break
+            yield chunk
+            done += len(chunk)
+        while done < want:
+            take = min(1 << 20, want - done)
+            yield b"\x00" * take
+            done += take
+
+    def _read_compressed(self, data, want):
+        """A compressed $DATA is stored in units of 2**comp_unit clusters. A unit
+        whose runs are shorter than the unit is compressed and inflated with
+        LZNT1; one stored at full length was left uncompressed."""
+        unit = (1 << data.comp_unit) * self.cluster
+        vcn_per_unit = 1 << data.comp_unit
+        produced = 0
+        # index the run list by VCN so a unit's clusters can be found
+        table, vcn = [], 0
+        for lcn, count in data.runs:
+            table.append((vcn, lcn, count))
+            vcn += count
+        total_vcn = vcn
+        for start in range(0, total_vcn, vcn_per_unit):
+            if produced >= want:
+                break
+            raw = self._unit_bytes(table, start, vcn_per_unit)
+            if raw is None:                       # wholly sparse unit
+                out = b"\x00" * unit
+            elif len(raw) >= unit:
+                out = raw[:unit]
+            else:
+                out = _lznt1_decompress(raw, unit)
+            take = min(len(out), want - produced)
+            yield out[:take]
+            produced += take
+
+    def _unit_bytes(self, table, start_vcn, count):
+        """The stored bytes of one compression unit, or None if it is all sparse.
+        A compressed unit occupies fewer clusters than the unit, and the rest of
+        its VCN span is a sparse run, so the stored length is what says so."""
+        out, any_real = bytearray(), False
+        for vcn, lcn, span in table:
+            lo, hi = max(vcn, start_vcn), min(vcn + span, start_vcn + count)
+            if lo >= hi:
+                continue
+            if lcn is None:
+                continue
+            any_real = True
+            out += read_at(self.fh, self.base + (lcn + (lo - vcn)) * self.cluster,
+                           (hi - lo) * self.cluster)
+        return bytes(out) if any_real else None
+
+
+def _lznt1_decompress(src, limit):
+    """Inflate an LZNT1 stream, the compression NTFS applies to a $DATA unit.
+
+    The format is a series of chunks, each a 16-bit header giving its stored
+    length and whether it is compressed, then either the literal bytes or a
+    stream of flag bytes where each bit says whether the next item is a literal
+    or a back reference. The split of a back reference into length and offset
+    bits widens as the output grows, which is what the shifting below tracks.
+    Described in the Linux-NTFS documentation, "Compressed files".
+    """
+    out = bytearray()
+    pos = 0
+    while pos + 2 <= len(src) and len(out) < limit:
+        header = struct.unpack_from("<H", src, pos)[0]
+        pos += 2
+        if header == 0:
+            break
+        size = (header & 0x0FFF) + 1
+        if pos + size > len(src):
+            break
+        chunk, pos = src[pos:pos + size], pos + size
+        if not header & 0x8000:                    # stored, not compressed
+            out += chunk
+            continue
+        start = len(out)
+        i = 0
+        while i < len(chunk) and len(out) - start < 4096:
+            flags = chunk[i]
+            i += 1
+            for bit in range(8):
+                if i >= len(chunk) or len(out) - start >= 4096:
+                    break
+                if not flags & (1 << bit):
+                    out.append(chunk[i])
+                    i += 1
+                    continue
+                if i + 2 > len(chunk):
+                    i = len(chunk)
+                    break
+                pair = struct.unpack_from("<H", chunk, i)[0]
+                i += 2
+                produced = len(out) - start
+                shift = 12
+                while shift > 4 and produced > (1 << (16 - shift)):
+                    shift -= 1
+                length = (pair & ((1 << shift) - 1)) + 3
+                delta = (pair >> shift) + 1
+                if delta > produced:
+                    return bytes(out)
+                src_pos = len(out) - delta
+                for _ in range(length):
+                    out.append(out[src_pos])
+                    src_pos += 1
+    return bytes(out[:limit])
+
+
 class Qnx4Walker:
     """List and read files from a QNX4 filesystem, same interface as the
     walkers above. A node is the kernel's inode number: block * 8 + index of
@@ -1580,6 +2220,12 @@ def print_tree(w, num, depth, maxdepth, budget, indent=0, pad=6):
         col = max(12, 44 - 2 * indent)
         shown = "" if isdir else f"{human(size):>11}"
         print(f"{' '*pad}{'  '*indent}{kind} {name:<{col}} {shown}  {_fmt_time(mtime)}")
+        # A file can carry content its own size does not account for. NTFS calls
+        # those alternate data streams; the walker that has them says so here,
+        # because nothing else in the listing would show that the bytes exist.
+        for sname, ssize in (getattr(w, "named_streams", lambda _n: [])(ino) or []):
+            print(f"{' '*pad}{'  '*indent}     stream {sname:<{max(6, col - 7)}} "
+                  f"{human(ssize):>11}")
         if isdir and depth < maxdepth:
             print_tree(w, ino, depth + 1, maxdepth, budget, indent + 1, pad)
 
@@ -2168,6 +2814,8 @@ def walker_for(kind, fh, base, size=None):
         return Fat32Walker(fh, base)
     if kind == "exfat":
         return ExfatWalker(fh, base)
+    if kind == "ntfs":
+        return NtfsWalker(fh, base)
     if kind == "efs":
         return EfsWalker(fh, base)
     if kind == "qnx4":
@@ -2254,6 +2902,44 @@ def identify_efs(fh, base, size):
         f"boot record  QSSL_F3S at +0x{boot['sig_at']:x}",
         f"root         logical unit {boot['root'][0]}, extent {boot['root'][1]}",
     ]
+
+
+def identify_ntfs(fh, base):
+    """Return ("ntfs", lines) for an NTFS volume at base, else None.
+
+    NTFS names itself in bytes 3..11 of its boot sector, and the geometry that
+    follows has to be self-consistent for the volume to be readable at all, so
+    both are required rather than the name alone.
+    """
+    b = read_at(fh, base, 512)
+    if len(b) < 512 or b[3:11] != NTFS_OEM or b[510:512] != b"\x55\xaa":
+        return None
+    bps = struct.unpack_from("<H", b, 11)[0]
+    spc = b[13]
+    if bps not in (512, 1024, 2048, 4096) or spc not in (1, 2, 4, 8, 16, 32, 64, 128):
+        return None
+    sectors = struct.unpack_from("<Q", b, 40)[0]
+    mft = struct.unpack_from("<Q", b, 48)[0]
+    mirr = struct.unpack_from("<Q", b, 56)[0]
+    serial = struct.unpack_from("<Q", b, 72)[0]
+    if not sectors or not mft:
+        return None
+    lines = [
+        f"bytes/sector {bps}   sectors/cluster {spc}",
+        f"volume       {human(sectors * bps)} ({sectors:,} sectors)",
+        f"$MFT         cluster {mft:,}   $MFTMirr cluster {mirr:,}",
+        f"serial       {serial:016x}",
+    ]
+    try:
+        w = NtfsWalker(fh, base)
+    except (ValueError, OSError, struct.error) as exc:
+        lines.append(f"walk         not possible: {exc}")
+        return "ntfs", lines
+    lines.append(f"record size  {w.rec_size} bytes   index block {w.idx_size} bytes")
+    label = w.volume_label()
+    if label is not None:
+        lines.append(f"label        {label or '(none)'}")
+    return "ntfs", lines
 
 
 def identify_fat(fh, base):
@@ -2352,6 +3038,10 @@ def identify_fs(fh, base, size=None):
     if ifs:
         return "QNX IFS boot image", ifs
 
+    ntfs = identify_ntfs(fh, base)
+    if ntfs:
+        return ntfs
+
     fat = identify_fat(fh, base)
     if fat:
         return fat
@@ -2448,18 +3138,31 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
     size = image_size(image)
     print("=" * 78)
     print(path)
+    ewf_parts = [] if segments else list(getattr(image, "paths", []) or [])
     if segments:
         print(f"  one segment of a split image: {len(segments)} segments joined, "
               f"{os.path.basename(segments[0])} .. {os.path.basename(segments[-1])}")
         print(f"    {describe_segment_sizes(image.sizes)}")
+    elif len(ewf_parts) > 1:
+        print(f"  an EWF acquisition of {len(ewf_parts)} segments, joined by the "
+              f"reader: {os.path.basename(ewf_parts[0])} .. "
+              f"{os.path.basename(ewf_parts[-1])}")
+    elif ewf_parts:
+        print("  an EWF acquisition of one segment")
     print(f"  {size:,} bytes ({human(size)})")
     print("=" * 78)
     # what volumes.json ties each volume to: the one file, or the first
     # segment of the set, with every segment and its size beside it
     image_rec = {"image": os.path.basename(segments[0] if segments else path)}
-    if segments:
-        image_rec["image_segments"] = [{"name": os.path.basename(p), "bytes": s}
-                                       for p, s in zip(image.paths, image.sizes)]
+    if segments or ewf_parts:
+        # A joined raw set records its own segment sizes; a reader over a
+        # container need not, so they are measured here rather than required.
+        parts = list(image.paths)
+        part_sizes = getattr(image, "sizes", None)
+        if part_sizes is None:
+            part_sizes = [os.path.getsize(q) for q in parts]
+        image_rec["image_segments"] = [{"name": os.path.basename(q), "bytes": s}
+                                       for q, s in zip(parts, part_sizes)]
 
     candidates, regions, sized_regions, triage = [], [], [], []
     containers, protective = set(), set()
@@ -2856,7 +3559,7 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
                     except Exception as exc:
                         print(f"        could not extract: {exc}")
 
-                if kind in ("fat32", "exfat", "etfs", "efs", "qnx4") and wanted:
+                if kind in ("fat32", "exfat", "ntfs", "etfs", "efs", "qnx4") and wanted:
                     if do_list:
                         print(f"        CONTENTS  (depth {list_depth})")
                         try:
@@ -2977,6 +3680,51 @@ def main(path, scan_limit_mib=256, do_list=False, list_depth=2, list_max=400,
         else:
             print("  VERDICT: no QNX6 superblock found.")
     print()
+
+
+def _ntfs_fixture_check(image_gz, listing):
+    """Walk the committed NTFS fixture and compare every file against the
+    hashes an independent reader recorded from the same image.
+
+    Returns (matched, expected, missing, different). The image is decompressed
+    in memory: the walker takes anything with seek and read, so no temporary
+    file is written and nothing outside this process is touched.
+    """
+    import gzip, hashlib, io
+    with gzip.open(image_gz, "rb") as gz:
+        img = io.BytesIO(gz.read())
+    want = {}
+    with open(listing, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if not line or line.startswith("#"):
+                continue
+            digest, path = line.split("  ", 1)
+            want[path] = digest
+    w = NtfsWalker(img, 0)
+    matched = missing = different = 0
+    have = {}
+    for path, ino, size, _mtime in collect(w, w.root):
+        have[path] = (ino, size)
+    for path, digest in want.items():
+        got = have.get(path)
+        if got is None:
+            missing += 1
+            continue
+        h = hashlib.sha256()
+        read = 0
+        try:
+            for chunk in w.read_file(got[0], got[1]):
+                h.update(chunk)
+                read += len(chunk)
+        except NtfsUnreadable:
+            different += 1
+            continue
+        if read == got[1] and h.hexdigest() == digest:
+            matched += 1
+        else:
+            different += 1
+    return matched, len(want), missing, different
 
 
 def self_test():
@@ -3704,6 +4452,184 @@ def self_test():
                 ok = False
             print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
 
+        # An EnCase/EWF acquisition is read through the vendored ewfprobe. The
+        # case that matters is the negative one: an .E01 must never be opened as
+        # raw bytes, because a container read that way holds no filesystem the
+        # walkers can see and the run would report an empty image rather than
+        # say it could not read the container.
+        # This literal is deliberately NOT EWF_SIGNATURE. A fixture built from
+        # the constant it is meant to verify moves with it, so the check passes
+        # on a build whose signature is wrong. It is the EWF file signature from
+        # the format documentation, written out again here on purpose.
+        TRUE_EWF_SIG = b"\x45\x56\x46\x09\x0d\x0a\xff\x00"    # "EVF\t\r\n\xff\0"
+        if EWF_SIGNATURE != TRUE_EWF_SIG:
+            ok = False
+            print(f"  [FAIL] EWF_SIGNATURE is {EWF_SIGNATURE!r}, "
+                  f"expected {TRUE_EWF_SIG!r}")
+        ewf_fake = os.path.join(d, "fake.E01")
+        with open(ewf_fake, "wb") as fh:
+            fh.write(TRUE_EWF_SIG + b"\x01\x01\x00\x00\x00" + b"\x00" * 4096)
+        # Deliberately not named *.img: this is not an image, and the build
+        # workflow harvests the self-test's synthetic images by that glob to
+        # smoke-test the frozen executables.
+        not_ewf = os.path.join(d, "not_an_acquisition.dat")
+        with open(not_ewf, "wb") as fh:
+            fh.write(b"PK\x03\x04not an acquisition" + b"\x00" * 512)
+
+        def _opened_as_raw(path):
+            """True when open_image handed back a plain file over the container."""
+            try:
+                handle = open_image(path)
+            except Exception:
+                return False
+            try:
+                return isinstance(handle, io.IOBase) and not hasattr(handle, "media_size")
+            finally:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
+
+        saved_reader = ewfprobe
+        try:
+            globals()["ewfprobe"] = None
+            try:
+                open_image(ewf_fake)
+                refused_without_reader = False
+            except ImageUnreadable as exc:
+                refused_without_reader = "ewfprobe" in str(exc)
+            except Exception:
+                refused_without_reader = False
+        finally:
+            globals()["ewfprobe"] = saved_reader
+
+        for label, cond in (
+                ("the EWF signature is recognised, and other bytes are not",
+                 looks_like_ewf(ewf_fake) and not looks_like_ewf(not_ewf)),
+                ("an .E01 is never opened as raw bytes",
+                 not _opened_as_raw(ewf_fake)),
+                ("a file that is not an acquisition still opens normally",
+                 _opened_as_raw(not_ewf)),
+                ("without the vendored reader an .E01 is refused, saying what "
+                 "is missing", refused_without_reader),
+                ("with the reader present a damaged acquisition is refused by "
+                 "it, not read",
+                 saved_reader is None or _ewf_refused_by_reader(ewf_fake))):
+            if not cond:
+                ok = False
+            print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+
+        # ---- NTFS ----------------------------------------------------
+        # A boot sector built by hand, so identification is tested against bytes
+        # this file did not read from a volume it also wrote.
+        ntfs_boot = bytearray(512)
+        ntfs_boot[3:11] = b"NTFS    "
+        struct.pack_into("<H", ntfs_boot, 11, 512)        # bytes per sector
+        ntfs_boot[13] = 8                                 # sectors per cluster
+        struct.pack_into("<Q", ntfs_boot, 40, 100000)     # total sectors
+        struct.pack_into("<Q", ntfs_boot, 48, 4)          # $MFT cluster
+        struct.pack_into("<Q", ntfs_boot, 56, 2)          # $MFTMirr cluster
+        struct.pack_into("<b", ntfs_boot, 64, -10)        # 1024-byte records
+        struct.pack_into("<b", ntfs_boot, 68, -12)        # 4096-byte index blocks
+        ntfs_boot[510:512] = b"\x55\xaa"
+        ntfs_img = os.path.join(d, "ntfs_boot.img")
+        open(ntfs_img, "wb").write(bytes(ntfs_boot) + b"\x00" * (1 << 20))
+        with open(ntfs_img, "rb") as nfh:
+            ntfs_named = identify_ntfs(nfh, 0)
+            ntfs_declined_by_mbr = parse_mbr(nfh) is None
+        bad_boot = bytearray(ntfs_boot)
+        bad_boot[13] = 7                                  # not a power of two
+        bad_img = os.path.join(d, "ntfs_bad.img")
+        open(bad_img, "wb").write(bytes(bad_boot) + b"\x00" * 4096)
+        with open(bad_img, "rb") as nfh:
+            ntfs_refused = identify_ntfs(nfh, 0) is None
+
+        # A mapping-pair list worked out by hand from the documented encoding.
+        # 0x31: a one-byte length and a three-byte offset, so 8 clusters at LCN
+        # 0x0C0000. 0x11: one and one, length 4 and offset 0xF8, which is -8
+        # SIGNED, so the next run starts BEFORE the last one, at 786,424. Read
+        # unsigned it would land at 786,680, which is the whole point of the
+        # case. 0x01: a length and no offset at all, which is a sparse run.
+        run_bytes = (
+            "3108" + "00000c"      # 8 clusters at LCN 0x0c0000
+            + "1104" + "f8"        # 4 more, offset -8, so LCN 786,424
+            + "0105"               # 5 clusters with no offset at all: sparse
+            + "00")                # end of list
+        runs = _ntfs_runs(bytes.fromhex(run_bytes), 0, 0)
+        runs_ok = runs == [(786432, 8), (786424, 4), (None, 5)]
+
+        # A real LZNT1 chunk lifted out of a volume written by mkntfs and
+        # ntfs-3g, with the plaintext it has to produce written out here rather
+        # than taken from the decoder.
+        lz_hex = (
+            "62b10061206c696e6520740068617420726570650061747320616e642000736f"
+            "20636f6d7072006573736573207765f86c6c0affab5f055f055f055f05ff5f05"
+            "5f055f055f055f055f055f055f05ff5f055f055f055f055f055f055f055f05ff"
+            "5f055f055f055f055f055f055f055f05ff5f05af02af02af02af02af02af02af"
+            "02ffaf02af02af02af02af02af02af02af02ffaf02af02af02af02af02af02af"
+            "02af02ffaf02af02af02af02af02af02af02af02ffaf02af02af02af02af02af"
+            "02af02af02ffaf02af02af02af02af02af02af02af02ffaf02af02af02af02af"
+            "02af02af02af02ffaf02af02af02af02af02af02af02af02ffaf02af02af02af"
+            "02af02af02af02af02ffaf02af02af02af02af02af02af02af02ffaf02af02af"
+            "02af02af02af02af02af02ffaf02af02af02af02af02af02af02af02ffaf02af"
+            "02af02af02af02af02af02af02ffaf02af02af02af02af02af02af02af0207af"
+            "02af02a402")
+        lz_chunk = bytes.fromhex(lz_hex)
+        lz_line = b"a line that repeats and so compresses well\n"
+        lz_ok = (_lznt1_decompress(lz_chunk, 4096)
+                 == (lz_line * (4096 // len(lz_line) + 2))[:4096])
+
+        # A record whose last sector was not written with the rest must be
+        # refused rather than parsed with the stamp still in it.
+        rec = bytearray(1024)
+        rec[0:4] = b"FILE"
+        struct.pack_into("<HH", rec, 4, 0x30, 3)          # usa at 0x30, two sectors
+        rec[0x30:0x32] = b"\xaa\x55"                      # the stamp
+        rec[0x32:0x36] = b"\x01\x02\x03\x04"             # what the sectors really hold
+        rec[510:512] = b"\xaa\x55"
+        rec[1022:1024] = b"\xaa\x55"
+        fixed = _ntfs_fixup(bytes(rec), 512, NTFS_FILE)
+        torn = bytearray(rec)
+        torn[1022:1024] = b"\x00\x00"                     # one sector missed the write
+        fixup_ok = (fixed is not None and fixed[510:512] == b"\x01\x02"
+                    and fixed[1022:1024] == b"\x03\x04"
+                    and _ntfs_fixup(bytes(torn), 512, NTFS_FILE) is None)
+
+        for label, cond in (
+                ("an NTFS boot sector is identified by its own geometry",
+                 bool(ntfs_named) and ntfs_named[0] == "ntfs"),
+                ("an NTFS boot sector is not read as a partition table",
+                 ntfs_declined_by_mbr),
+                ("a boot sector naming NTFS with impossible geometry is refused",
+                 ntfs_refused),
+                ("a run list decodes, including a run that steps backwards and "
+                 "a sparse one", runs_ok),
+                ("an LZNT1 chunk inflates to the bytes it was made from", lz_ok),
+                ("a record's sector fixups are applied, and a torn one is "
+                 "refused", fixup_ok)):
+            if not cond:
+                ok = False
+            print(f"  [{'PASS' if cond else 'FAIL'}] {label}")
+
+        ntfs_fix = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                "tests", "fixtures", "ntfs-fixture.img.gz")
+        ntfs_want = ntfs_fix[:-len(".img.gz")] + ".sha256"
+        if os.path.isfile(ntfs_fix) and os.path.isfile(ntfs_want):
+            got, want, missing, differ = _ntfs_fixture_check(ntfs_fix, ntfs_want)
+            cond = got and not missing and not differ
+            if not cond:
+                ok = False
+            print(f"  [{'PASS' if cond else 'FAIL'}] every file of the NTFS "
+                  f"fixture matches what an independent reader recorded "
+                  f"({got} of {want}"
+                  + (f", {missing} missing" if missing else "")
+                  + (f", {differ} different" if differ else "") + ")")
+        else:
+            # Said plainly rather than silently: a check that did not run is not
+            # a check that passed. The frozen executable carries no fixtures.
+            print("  [SKIP] the NTFS fixture is not beside this script, so the "
+                  "walk was not compared against it")
+
         print()
         print("  SELF-TEST PASSED. The detector reports positives and negatives"
               if ok else
@@ -3783,10 +4709,11 @@ getting the files out, without mounting:
 
 listing contents:
   --list walks each filesystem it identified and prints the tree. It handles
-  qnx6, QNX4, ext2/3/4, FAT32, exFAT, the QNX flash filesystems ETFS and EFS,
-  and QNX IFS boot images, follows qnx6 long filenames and ext4 extent trees,
-  and reads only. --depth sets how far down it goes and --list-max caps the
-  number of entries per filesystem so a large volume cannot flood the terminal.
+  qnx6, QNX4, ext2/3/4, FAT32, exFAT, NTFS, the QNX flash filesystems ETFS and
+  EFS, and QNX IFS boot images, follows qnx6 long filenames and ext4 extent
+  trees, and reads only. --depth sets how far down it goes and --list-max caps
+  the number of entries per filesystem so a large volume cannot flood the
+  terminal. An NTFS listing also names any alternate data stream it finds.
 
 what it reports:
   Every superblock copy it can find, grouped into generations by serial. The
@@ -3983,7 +4910,7 @@ if __name__ == "__main__":
     import argparse
     ap = argparse.ArgumentParser(
         prog="qnxprobe.py",
-        description="Read QNX6, QNX4, ETFS, EFS, ext2/3/4, FAT32 and exFAT "
+        description="Read QNX6, QNX4, ETFS, EFS, ext2/3/4, FAT32, exFAT and NTFS "
                     "filesystems, and QNX IFS boot images, out of raw disk "
                     "images: identify each by its own on-disk structure rather "
                     "than trusting a partition type byte, list, and extract to a "
@@ -4001,7 +4928,7 @@ if __name__ == "__main__":
                          "the detector reports both ways, then delete them")
     ap.add_argument("--list", action="store_true",
                     help="walk each filesystem found and list its contents "
-                         "(qnx6, qnx4, ext2/3/4, FAT32, exFAT, ETFS and EFS)")
+                         "(qnx6, qnx4, ext2/3/4, FAT32, exFAT, NTFS, ETFS and EFS)")
     ap.add_argument("--depth", type=int, default=2, metavar="N",
                     help="how deep to walk with --list (default: 2)")
     ap.add_argument("--list-max", type=int, default=400, metavar="N",
@@ -4058,8 +4985,8 @@ if __name__ == "__main__":
                      extract=args.extract, only=args.only, zf=zf,
                      do_triage=args.triage, exclude=args.exclude,
                      reporter=reporter, manifest=manifest)
-            except SplitImageError as exc:
-                # a segment set that is not whole: said out loud and left
+            except (SplitImageError, ImageUnreadable) as exc:
+                # a segment set that is not whole, or an image this tool cannot open: said out loud and left
                 # unread, never joined around, and the exit status says so
                 print("=" * 78)
                 print(p)

--- a/scripts/vendor/vendored.json
+++ b/scripts/vendor/vendored.json
@@ -3,14 +3,27 @@
     {
       "path": "scripts/vendor/qnxprobe.py",
       "name": "qnxprobe",
-      "version": "1.13",
+      "version": "1.14",
       "upstream": "https://github.com/abrignoni/qnxprobe",
       "upstream_file": "qnxprobe.py",
-      "commit": "d6a9c566d784945d17037664ada4560ab838bb22",
-      "commit_date": "2026-09-04T20:06:08-04:00",
-      "sha256": "29a3b0156ef4a5ba2e15896274a5806ef67891bed291cb5cc5a462a7c1035056",
+      "commit": "19366760df6e2f9f898a49ec878c1ee01da03a91",
+      "commit_date": "2026-09-08T23:23:54-04:00",
+      "sha256": "544ff3f642a96894a73cf636287cb68ab65e843296ae8a5d161b9ade10b1a105",
       "licence": "MIT",
       "licence_file": "scripts/vendor/LICENSE-qnxprobe",
+      "note": "Copied verbatim. Fix upstream and re-vendor; edits here are reverted by the next sync."
+    },
+    {
+      "path": "scripts/vendor/ewfprobe.py",
+      "name": "ewfprobe",
+      "version": "0.1.0",
+      "upstream": "https://github.com/abrignoni/ewfprobe",
+      "upstream_file": "ewfprobe.py",
+      "commit": "f1ee155a612eeb78561cdb538e856252d4c8f68e",
+      "commit_date": "2026-09-08T21:58:07-04:00",
+      "sha256": "304616fcdd362339c6890a100eeaba824822f518a09831eb50ed75692f3e52b8",
+      "licence": "MIT",
+      "licence_file": "scripts/vendor/LICENSE-ewfprobe",
       "note": "Copied verbatim. Fix upstream and re-vendor; edits here are reverted by the next sync."
     }
   ]

--- a/vleapp.py
+++ b/vleapp.py
@@ -154,7 +154,7 @@ def main():
                               "'fs' for a folder containing extracted files with normal paths and names, "
                               "'tar', 'zip', or 'gz' for compressed packages containing files with normal names, "
                               "'file' for a single file input, "
-                              "'raw' for a raw disk image whose QNX6, QNX4, ETFS, EFS, ext, FAT32 or exFAT volumes and QNX IFS boot images are read without mounting, "
+                              "'raw' for a raw disk image or an EnCase/EWF (.E01) acquisition, whose QNX6, QNX4, ETFS, EFS, ext, FAT32, exFAT or NTFS volumes and QNX IFS boot images are read without mounting, "
                               "'iva' for a Berla iVe .iVa export."))
     parser.add_argument('-o', '--output_path', required=False, action="store",
                         help='Path to base output folder (this must exist)')

--- a/vleappGUI.py
+++ b/vleappGUI.py
@@ -201,11 +201,12 @@ def scroll(event):
     parent.event_generate('<MouseWheel>', delta=event.delta, when='now')
 
 
-# Extensions conventionally given to a raw disk image. Everything a raw image
-# run needs is decided by reading the image, so this list only has to get the
-# file past type selection; an image named anything else is still reachable
-# from the command line with -t raw.
-RAW_IMAGE_SUFFIXES = ('img', 'bin', 'dd', 'raw', '001')
+# Extensions conventionally given to a raw disk image, plus the one an
+# EnCase/EWF acquisition carries. Everything a raw image run needs is decided by
+# reading the image, so this list only has to get the file past type selection;
+# an image named anything else is still reachable from the command line with
+# -t raw. An .E01 is the first segment of its set and the reader joins the rest.
+RAW_IMAGE_SUFFIXES = ('img', 'bin', 'dd', 'raw', '001', 'e01')
 
 
 def ValidateInput():
@@ -577,10 +578,10 @@ def select_input(button_type):
         input_filename = tk_filedialog.askopenfilename(parent=main_window,
                                                        title='Select a file',
                                                        filetypes=(('All supported files',
-                                                                   '*.tar *.zip *.gz *.img *.bin *.dd *.raw *.001 *.iVa'),
+                                                                   '*.tar *.zip *.gz *.img *.bin *.dd *.raw *.001 *.E01 *.iVa'),
                                                                   ('tar file', '*.tar'), ('zip file', '*.zip'),
                                                                   ('gz file', '*.gz'),
-                                                                  ('raw disk image', '*.img *.bin *.dd *.raw *.001'),
+                                                                  ('raw disk image or acquisition', '*.img *.bin *.dd *.raw *.001 *.E01'),
                                                                   ('Berla iVe export', '*.iVa')))
     else:
         input_filename = tk_filedialog.askdirectory(parent=main_window, title='Select a folder')


### PR DESCRIPTION
The vendored reader was eight commits behind. Taking it forward adds NTFS, and vendoring `ewfprobe` beside it makes an EnCase/EWF acquisition a raw image input like any other: qnxprobe imports ewfprobe from that directory, and without it an `.E01` is refused with a message saying what is missing rather than read as raw bytes, which would find no filesystem and look like an empty image.

- `scripts/vendor/qnxprobe.py` at 1.14. NTFS: resident and non-resident data, sparse runs, LZNT1 compression, attributes that overflowed into other MFT records, directory indexes in both forms with the sector fixups applied, and alternate data streams named in a listing.
- `scripts/vendor/ewfprobe.py`, new. Reads an `.E01` and the segments beside it as one seekable image.
- `.E01` joins the raw-image suffixes the launcher maps onto `-t raw`, and the file dialog offers it.

Nothing else in the seeker changed: an EWF set is joined by the reader and reported through the `image_segments` list `volumes.json` already carries, which `_warn_incomplete_volumes()` already repeats in the run log.

Measured end to end. A 28.6 GiB single-segment acquisition of a FAT32 volume ran through `vleapp.py -t raw` and reported. A five-segment acquisition of a 16 MiB NTFS volume was joined, walked and staged at 490 files, and `FileSeekerRaw`'s own search returned the LZNT1-compressed file from it with the sha256 an independent reader recorded for that file, so a compressed NTFS file inside a segmented acquisition reaches an artifact byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)