### PR TITLE
Drop the stale installedappsGass clause from the raw image doc

### DIFF
--- a/admin/docs/raw_image_input.md
+++ b/admin/docs/raw_image_input.md
@@ -99,9 +99,8 @@ none of them a file the seeker got wrong:
 - First-match order. A few artifacts read one file out of several equivalent
   copies and take the first the seeker returns. The zip, tar and raw seekers each
   list a directory in their own order, so which copy wins can differ. On Android
-  `installedappsGass` labels its source by the view it read, and `walstrings`
-  numbers its rows by arrival. This is a property of those artifacts and shows
-  between the zip and tar routes too.
+  `walstrings` numbers its rows by arrival. This is a property of those artifacts
+  and shows between the zip and tar routes too.
 - Companion files beside the zip. Some artifacts read a file a tool exported next
   to the acquisition rather than inside it. iOS keychain artifacts read a
   `<udid>_keychain.plist` sitting beside the zip on disk, found only when the


### PR DESCRIPTION
The shared raw-image doc's First-match order bullet still listed `installedappsGass` among the artifacts whose output depends on which copy the seeker returns first. It no longer does: it reads every `gass.db` through `unique_files` and takes each row's user from the evidence path. ALEAPP dropped the clause in abrignoni/ALEAPP@1bfc142a, and this brings this copy back to byte-identical with ALEAPP's (blob `a918d0ec`).

Doc only, one file, no code change. The `walstrings` half of the bullet stays because it is still true: `walStrings.py` numbers each output file with a counter incremented per file, and `unique_files` returns files in order of first appearance, so which file is numbered 1 still follows the seeker even though the set of files no longer varies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)